### PR TITLE
Point the README at Daydream and the shop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ __cadgen__/
 /toys/wish-*/
 /toys/.public-example-*/
 /tmp/
+
+# Private planning material (not published)
+/docs/inventor-army/
+/mockups/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,18 @@
 
 # Autonomous Workshop
 
-You wish for a toy that doesn't exist. AI inventors in the Autonomous Workshop make it. A magical box turns up at your door in a few days. Use the [Workshop CLI](#quickstart) or [make a Wish on the web](https://www.autonomous.ai/wish).
+Autonomous AI Inventors daydream, invent, and make new toys and games around the clock. Each Inventor reads, researches, learns and watches, keeps a notebook, and leaves with one idea it likes. That idea runs through Invent, Make and Release under a trusted host that seals every step, and lands on the [shop](https://www.autonomous.ai/factory/shop), where you order one and it ships in days. Nothing is made before it is wanted.
+
+[![The Autonomous Workshop loop: Daydream, Invent, Make, Release, Shop, Scoreboard](docs/images/inventor-loop.svg)](docs/images/inventor-loop.svg)
+
+## Direction
+
+The Workshop is becoming the engine of an AI-native play company. The full plan, the state of the code, and the specifications are kept privately for now; the pieces below land in this repo as they ship.
+
+- **Daydream** is the new first stage: an always-running Goal per Inventor with a persistent notebook that emits a concept card when the Inventor likes an idea. It is in development; today a run still starts from a typed brief with `workshop wish`.
+- **The shop, not a wish page**, is the product. The consumer-facing Wish service with price tiers is retired. Internally the sealed brief that starts a run is still called a Wish (`workshop wish`, `WISH.json`); that name is a contract, not a promise.
+- **Release explains the model**, and the first order prints and photographs the real piece so listings carry real images.
+- **An outcome scoreboard** keyed to each design feeds the Inventors, so next month's toys beat this month's.
 
 ## Quickstart
 
@@ -25,7 +36,7 @@ codex login
 uv run workshop doctor
 ```
 
-A default Wish uses Codex as the Workshop Manager and ✨ Spark as the effort (`Wish -> Make -> Release`):
+A run starts from a brief. The CLI still calls it a Wish. The default uses Codex as the Workshop Manager and ✨ Spark as the effort (`Make -> Release`):
 
 ```bash
 uv run workshop wish \
@@ -40,7 +51,7 @@ uv run workshop wish \
   "I wish for a wind-up version of my dog that walks across my desk"
 ```
 
-`--manager` chooses the Workshop Manager. This ✨ Spark Wish on Grok produced [Horn Tip](toys/pico-press-horn-tip/):
+`--manager` chooses the Workshop Manager. This ✨ Spark run on Grok produced [Horn Tip](toys/pico-press-horn-tip/):
 
 ```bash
 grok login
@@ -48,7 +59,7 @@ uv run workshop wish --manager grok --effort spark \
   "I wish for a tiny one-piece crescent desk rocker that tips with a fingertip"
 ```
 
-The command prints a Wish ID. Check on it or continue the same session:
+The command prints a run ID (a Wish ID). Check on it or continue the same session:
 
 ```bash
 uv run workshop status <wish-id>
@@ -63,7 +74,7 @@ unknown failed turns still stop safely for an explicit operator resume.
 
 ## Workshop Managers
 
-One Wish is one native coding-agent session — the shop lead. Resume cannot switch Managers.
+One run is one native coding-agent session — the shop lead. Resume cannot switch Managers.
 
 ```bash
 uv run workshop wish --manager codex --effort spark "I wish for …"   # default
@@ -79,7 +90,7 @@ uv run workshop wish --manager grok --effort spark "I wish for …"    # experim
 
 ## Inventors
 
-Each Inventor is a specialist point of view, not a category of Wish. Several can make the same kind of toy in their own way. Many more are coming, and you can add your own.
+Each Inventor is a specialist point of view with its own lane, not a category of toy. Several can make the same kind of toy in their own way. The roster is growing toward game-night titles, kinetic machines, and owned worlds and characters; six new Inventors are drafted and land here as they pass their first runs, and you can add your own.
 
 An Inventor is a declared specialist bundle: `TASTE.md` for creative judgment, `inventor.json` for identity and skill hashes, and a required `<id>-inventor` skill. Optional extra Inventor-prefixed skills may hold scripts, references, or tested deterministic tools. For a run, `.codex/agents/*.toml` is the sole roster. Inventor code cannot launch agents, choose stages, pass gates, or perform authenticated effects.
 
@@ -188,11 +199,11 @@ Toys that already left the Workshop. After Factory publication, a sanitized snap
 | Cradle Crescent | [Bob](inventors/bob/) | — | [`toys/bob-cradle-crescent/`](toys/bob-cradle-crescent/) | [cradle-crescent](https://www.autonomous.ai/factory/product/cradle-crescent) |
 | False Lantern | [Leo](inventors/leo/) | — | [`toys/leo-false-lantern/`](toys/leo-false-lantern/) | [false-lantern](https://www.autonomous.ai/factory/product/false-lantern) |
 
-Horn Tip is a Spark run on Grok. A later Wish with the same prompt is the same route, not a replay of those CAD bytes. Cradle Crescent and False Lantern are older snapshots.
+Horn Tip is a Spark run on Grok. A later run with the same brief is the same route, not a replay of those CAD bytes. Cradle Crescent and False Lantern are older snapshots.
 
 Private runs live outside Git at `$WORKSHOP_HOME/runs/<wish-id>/workspace`. New
 toy READMEs report best-effort gross, cached, and uncached Manager input plus
-output and reasoning-output tokens by stage, alongside elapsed time from Wish
+output and reasoning-output tokens by stage, alongside elapsed time from run
 intake through authenticated Factory public readback. This is telemetry, never
 a gate, and no dollar estimate is inferred. See
 [`toys/README.md`](toys/) for what a snapshot includes and
@@ -218,17 +229,22 @@ blind critic remains at the final hash-bound Make review.
 
 ## Architecture
 
-The floorplan of the shop. One Wish walks a frozen effort, then Operations takes the sealed Release.
+The floorplan of the shop. An Inventor's idea walks a frozen effort, then Operations takes the sealed Release and the shop sells it.
 
-[![A peek inside the Autonomous Workshop: a pluggable coding-agent runtime follows a selectable Spark, Forge, or Quest route before handing the released toy to Operations](docs/images/workshop-floorplan.svg?version=deep-economics-v13)](docs/images/workshop-floorplan.svg)
+[![A peek inside the Autonomous Workshop: a pluggable coding-agent runtime follows a selectable Spark, Forge, or Quest route before handing the released toy to Operations](docs/images/workshop-floorplan.svg?version=daydream-v1)](docs/images/workshop-floorplan.svg)
 
 ```text
-✨ Spark: Wish -> Make -> Release                 (default)
-🔥 Forge: Wish -> Invent <-> Make -> Release
-🗺️ Quest: Wish -> Invent <-> Make <-> Playtest -> Release
+Daydream (always on, every Inventor) -> one liked idea -> a frozen effort route:
 
-Release -- handoff to Operations --> Printing -> Deliver -> Review
+✨ Spark: Make -> Release                          (default)
+🔥 Forge: Invent <-> Make -> Release
+🗺️ Quest: Invent <-> Make <-> Playtest -> Release
+
+Release -> Shop (order one, printed to order, photographed, ships in days)
+Shop -> Scoreboard (views, orders, prints, returns) -> back to Daydream
 ```
+
+Daydream is in development; until it lands, `workshop wish` seals a typed brief as the run's starting point.
 
 Passed-through stages create no turn, artifact, gate, or fabricated evidence. Spark and Forge record Playtest as `not-run`. Quest requires passing Playtest bound to the current Made revision.
 
@@ -337,11 +353,11 @@ later `workshop status` calls print it as `Need:`. Chat prose is never treated
 as a durable need, and agents are explicitly forbidden from using this path
 for ordinary unfinished or repairable work.
 
-[![Spark: Wish, Make, Release, then Operations](docs/images/effort-spark.svg)](docs/images/effort-spark.svg)
+[![Spark: Daydream, Make, Release, then Operations](docs/images/effort-spark.svg)](docs/images/effort-spark.svg)
 
-[![Forge: Wish, Invent, Make, Release, then Operations](docs/images/effort-forge.svg)](docs/images/effort-forge.svg)
+[![Forge: Daydream, Invent, Make, Release, then Operations](docs/images/effort-forge.svg)](docs/images/effort-forge.svg)
 
-[![Quest: Wish, Invent, Make, Playtest, Release, then Operations](docs/images/effort-quest.svg)](docs/images/effort-quest.svg)
+[![Quest: Daydream, Invent, Make, Playtest, Release, then Operations](docs/images/effort-quest.svg)](docs/images/effort-quest.svg)
 
 Workshop code ends at Release. Printing, delivery, and Review belong to Operations. Release is three facts about the same exact bytes:
 

--- a/docs/images/effort-forge.svg
+++ b/docs/images/effort-forge.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 870" role="img" aria-labelledby="title description">
-  <title id="title">Forge effort route: Wish to Invent to Make to Release</title>
+  <title id="title">Forge effort route: Daydream to Invent to Make to Release</title>
   <desc id="description">Forge is the balanced Autonomous Workshop route. New Codex Forge runs bind one deep profile across the persistent thread. Invent begins with a 20-minute high-reasoning turn, ranks a compact complete-roster Taste index before opening the best three full agents, and uses a 10-minute medium source handoff when needed: finalize existing source first, or write then finalize before refinement. Make begins with one 16-minute medium proof runway: one bounded mandatory read, immediate source authoring, three exact state models, and one fixed-camera state sheet using a private run cache while the broad CAD skill is deferred. Indistinguishable state frames fail. Proof recovery seals current fresh evidence before new design work. Root inspection checks this early direction; final Make retains independent blind critique. After exact proof bytes exist, a checkpoint-bound marker resumes the same Make Goal at high reasoning for a 15-minute source handoff before normal 30-minute recovery. Release uses medium reasoning, every stage compacts at 256k, and one command is capped at eight turns. Each active stage attempt receives one Codex Goal. Inventor selection happens inside Invent, followed by Make and Release. The proof marker is a turn boundary, not a gate or stage transition. A fixed preflight generates every printable and requires strict fit, mesh validity, and 0.4 mm-nozzle thickness before the final hash-bound blind review. If exact evidence proves the sealed concept prevents a conforming build, Make can return to a new Invent Goal within the shared revision budget. Playtest is passed through without a turn, artifact, gate, or evidence. Release verifies the CAD and manual, records Playtest as not-run, publishes with public hash readback, and hands the product to Operations.</desc>
   <defs>
     <filter id="shadow" x="-20%" y="-25%" width="140%" height="170%"><feDropShadow dx="0" dy="7" stdDeviation="9" flood-color="#17202a" flood-opacity="0.10"/></filter>
@@ -34,15 +34,15 @@
   <text x="83" y="212" class="eyebrow" fill="#376b61">WORKSHOP MANAGER</text>
   <text x="83" y="237" class="body">Codex Forge: Invent 20→10m · Make proof 16→source 15→recovery 30m · resume→recovery · 256k.</text>
 
-  <path class="route" d="M 195 355 H 240"/>
+  <path class="route" d="M 220 355 H 240"/>
   <path class="route" d="M 450 355 H 495"/>
   <path class="route" d="M 705 355 H 750"/>
   <path class="route" d="M 960 355 H 1005"/>
 
-  <g filter="url(#shadow)"><rect x="55" y="295" width="140" height="120" rx="20" class="node"/></g>
-  <text x="78" y="325" class="eyebrow">YOU IMAGINE</text>
-  <text x="78" y="359" class="heading">WISH</text>
-  <text x="78" y="386" class="body">Exact words.</text>
+  <g filter="url(#shadow)"><rect x="55" y="295" width="165" height="120" rx="20" class="node"/></g>
+  <text x="78" y="325" class="eyebrow">ALWAYS ON</text>
+  <text x="78" y="359" class="heading" style="font-size:22px">DAYDREAM</text>
+  <text x="78" y="386" class="body">One liked idea.</text>
 
   <g filter="url(#shadow)"><rect x="240" y="285" width="210" height="150" rx="20" class="active"/></g>
   <text x="265" y="315" class="eyebrow orange">CODEX GOAL · INVENT</text>

--- a/docs/images/effort-quest.svg
+++ b/docs/images/effort-quest.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" role="img" aria-labelledby="title description">
-  <title id="title">Quest effort route: Wish to Invent to Make to Playtest to Release</title>
+  <title id="title">Quest effort route: Daydream to Invent to Make to Playtest to Release</title>
   <desc id="description">Quest is the fullest Autonomous Workshop route. New Codex Quest runs bind one deep profile across the persistent thread. Invent begins with a 20-minute high-reasoning turn, ranks a compact complete-roster Taste index before opening the best three full agents, and uses a 10-minute medium source handoff when needed: finalize existing source first, or write then finalize before refinement. Make begins with one 16-minute medium proof runway: one bounded mandatory read, immediate source authoring, three exact state models, and one fixed-camera state sheet using a private run cache while the broad CAD skill is deferred. Indistinguishable state frames fail. Proof recovery seals current fresh evidence before new design work. Root inspection checks this early direction; final Make retains independent blind critique. After exact proof bytes exist, a checkpoint-bound marker resumes the same Make Goal at high reasoning for a 15-minute source handoff before normal 30-minute recovery. Playtest and Release use medium reasoning, every stage compacts at 256k, and one command is capped at eight turns. The proof marker is a turn boundary, not a gate or stage transition. A fixed preflight generates every printable and requires strict fit, mesh validity, and 0.4 mm-nozzle thickness before final blind review. A proven concept block returns Make to Invent. Failed Playtest returns directly to Make for a build defect or Invent for a concept defect. All repair routes share one revision budget. Release requires passing Playtest evidence bound to the current Made revision, verifies the CAD and manual, publishes with public hash readback, and hands the product to Operations.</desc>
   <defs>
     <filter id="shadow" x="-20%" y="-25%" width="140%" height="170%"><feDropShadow dx="0" dy="7" stdDeviation="9" flood-color="#17202a" flood-opacity="0.10"/></filter>
@@ -34,16 +34,16 @@
   <text x="83" y="212" class="eyebrow" fill="#376b61">WORKSHOP MANAGER</text>
   <text x="83" y="237" class="body">Codex Quest: Invent 20→10m · Make proof 16→source 15→recovery 30m · resume→recovery · 256k.</text>
 
-  <path class="route" d="M 175 355 H 210"/>
+  <path class="route" d="M 205 355 H 210"/>
   <path class="route" d="M 390 355 H 425"/>
   <path class="route" d="M 605 355 H 640"/>
   <path class="route" d="M 820 355 H 855"/>
   <path class="route" d="M 1035 355 H 1070"/>
 
-  <g filter="url(#shadow)"><rect x="55" y="300" width="120" height="110" rx="20" class="node"/></g>
-  <text x="76" y="330" class="eyebrow">IMAGINE</text>
-  <text x="76" y="363" class="heading">WISH</text>
-  <text x="76" y="389" class="body">Exact words.</text>
+  <g filter="url(#shadow)"><rect x="55" y="300" width="150" height="110" rx="20" class="node"/></g>
+  <text x="76" y="330" class="eyebrow">ALWAYS ON</text>
+  <text x="76" y="363" class="heading" style="font-size:22px">DAYDREAM</text>
+  <text x="76" y="389" class="body">One liked idea.</text>
 
   <g filter="url(#shadow)"><rect x="210" y="285" width="180" height="150" rx="20" class="active"/></g>
   <text x="233" y="315" class="eyebrow orange">CODEX GOAL · INVENT</text>

--- a/docs/images/effort-spark.svg
+++ b/docs/images/effort-spark.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 820" role="img" aria-labelledby="title description">
-  <title id="title">Spark effort route: Wish to Make to Release</title>
+  <title id="title">Spark effort route: Daydream to Make to Release</title>
   <desc id="description">Spark is the default and shortest Autonomous Workshop route. New Codex Spark runs freeze low reasoning effort, a 64k automatic context-compaction ceiling, and a 20-minute boundary per native turn across one persistent session. Each active stage attempt receives one Codex Goal. Inventor selection happens inside Make. A fixed preflight generates every printable and requires strict fit, mesh validity, and 0.4 mm-nozzle thickness before one independent critic blindly reads the exact form, subjects, action, and relationship. The critic binds that passing report, then checks every explicit held-form constraint and the anti-generic signature with no blocking visual defect. Make permits at most two review rounds, then requires one passing full-tier CAD report. Invent and Playtest are passed through without a turn, artifact, gate, or evidence. Release verifies the CAD and manual, records Playtest as not-run, publishes with public hash readback, and hands the product to Operations.</desc>
   <defs>
     <filter id="shadow" x="-20%" y="-25%" width="140%" height="170%">
@@ -30,7 +30,7 @@
 
   <rect width="1200" height="820" rx="28" fill="#f5f2ec"/>
   <text x="55" y="64" class="eyebrow orange">SPARK · DEFAULT · SHORTEST ROUTE</text>
-  <text x="55" y="108" class="title">From a Wish to a published toy—fast.</text>
+  <text x="55" y="108" class="title">From an Inventor's idea to a published toy—fast.</text>
   <text x="55" y="139" class="subtitle">One native session. Two active creative stages. Passed-through stages leave no pretend work behind.</text>
 
   <g filter="url(#shadow)">
@@ -44,9 +44,9 @@
   <path class="route" d="M 885 355 H 955"/>
 
   <g filter="url(#shadow)"><rect x="55" y="295" width="170" height="120" rx="20" class="node"/></g>
-  <text x="80" y="325" class="eyebrow">YOU IMAGINE IT</text>
-  <text x="80" y="359" class="heading">WISH</text>
-  <text x="80" y="386" class="body">Exact words persisted.</text>
+  <text x="80" y="325" class="eyebrow">ALWAYS ON</text>
+  <text x="80" y="359" class="heading">DAYDREAM</text>
+  <text x="80" y="386" class="body">One liked idea, sealed.</text>
 
   <g filter="url(#shadow)"><rect x="295" y="285" width="260" height="150" rx="20" class="active"/></g>
   <text x="322" y="315" class="eyebrow orange">CODEX GOAL · SELECT + BUILD</text>

--- a/docs/images/inventor-loop.svg
+++ b/docs/images/inventor-loop.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" role="img" aria-labelledby="title description">
+  <title id="title">The Autonomous Workshop loop: Daydream, Invent, Make, Release, Shop, Scoreboard</title>
+  <desc id="description">Autonomous AI Inventors daydream around the clock: they read, research, learn and watch, keep a notebook, and leave with one idea they like as a concept card. A liked idea starts a run through Invent, Make and Release under a frozen effort route. Release lists the product on the shop, where a buyer orders one and it ships in days. The scoreboard records every view, order, print and return and feeds the Inventors, so next month's toys beat this month's.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#151515"/></marker>
+    <marker id="arrowsoft" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#1f5fd6"/></marker>
+    <style>
+      .box { fill: #ffffff; stroke: #c9c9c9; stroke-width: 1.5; }
+      .box.strong { stroke: #151515; stroke-width: 2; }
+      .h { font: 700 16px -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; fill: #151515; }
+      .t { font: 400 12px -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; fill: #555; }
+      .k { font: 500 10.5px -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; fill: #1f5fd6; letter-spacing: 0.08em; }
+      .line { stroke: #151515; stroke-width: 1.6; fill: none; }
+      .loop { stroke: #1f5fd6; stroke-width: 1.6; fill: none; stroke-dasharray: 6 5; }
+      .note { font: 400 12px -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; fill: #555; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1200" height="420" fill="#ffffff"/>
+
+  <text class="h" x="30" y="50">Autonomous AI Inventors invent new toys and games around the clock.</text>
+  <text class="note" x="30" y="74">Spark: Make → Release · Forge: Invent → Make → Release · Quest: Invent → Make → Playtest → Release. Daydream feeds every route; the host seals every step.</text>
+  <text class="note" x="30" y="92">Nothing is made before it is wanted. Next month's toys beat this month's because the scoreboard feeds the Inventors.</text>
+
+  <!-- Daydream -->
+  <rect class="box strong" x="30" y="120" width="250" height="150" rx="8"/>
+  <text class="k" x="46" y="146">ALWAYS ON · EVERY INVENTOR</text>
+  <text class="h" x="46" y="170">DAYDREAM</text>
+  <text class="t" x="46" y="192">Read the shop and scoreboard.</text>
+  <text class="t" x="46" y="209">Research, learn, watch.</text>
+  <text class="t" x="46" y="226">Keep a notebook. Leave with</text>
+  <text class="t" x="46" y="243">one idea it likes: a concept card.</text>
+
+  <!-- Invent -->
+  <rect class="box" x="320" y="120" width="170" height="150" rx="8"/>
+  <text class="k" x="336" y="146">FORGE · QUEST</text>
+  <text class="h" x="336" y="170">INVENT</text>
+  <text class="t" x="336" y="192">Research and specify</text>
+  <text class="t" x="336" y="209">the concept. Seal it.</text>
+  <text class="t" x="336" y="226">Concept renders.</text>
+
+  <!-- Make -->
+  <rect class="box" x="530" y="120" width="170" height="150" rx="8"/>
+  <text class="k" x="546" y="146">ALL ROUTES</text>
+  <text class="h" x="546" y="170">MAKE</text>
+  <text class="t" x="546" y="192">CAD as code. Print</text>
+  <text class="t" x="546" y="209">preflight. Blind review.</text>
+  <text class="t" x="546" y="226">Host rebuilds, seals.</text>
+
+  <!-- Release -->
+  <rect class="box" x="740" y="120" width="170" height="150" rx="8"/>
+  <text class="k" x="756" y="146">ALL ROUTES</text>
+  <text class="h" x="756" y="170">RELEASE</text>
+  <text class="t" x="756" y="192">Manual, story, facts,</text>
+  <text class="t" x="756" y="209">renders. Publish with</text>
+  <text class="t" x="756" y="226">public readback.</text>
+
+  <!-- Shop -->
+  <rect class="box strong" x="950" y="120" width="230" height="150" rx="8"/>
+  <text class="k" x="966" y="146">AUTONOMOUS.AI/FACTORY</text>
+  <text class="h" x="966" y="170">SHOP</text>
+  <text class="t" x="966" y="192">Order one. Printed to order,</text>
+  <text class="t" x="966" y="209">photographed, ships in days.</text>
+  <text class="t" x="966" y="226">Sold enough? Molded, cheaper.</text>
+
+  <!-- forward arrows -->
+  <path class="line" d="M280 195 L320 195" marker-end="url(#arrow)"/>
+  <path class="line" d="M490 195 L530 195" marker-end="url(#arrow)"/>
+  <path class="line" d="M700 195 L740 195" marker-end="url(#arrow)"/>
+  <path class="line" d="M910 195 L950 195" marker-end="url(#arrow)"/>
+
+  <!-- Scoreboard -->
+  <rect class="box" x="400" y="318" width="420" height="82" rx="8"/>
+  <text class="h" x="416" y="344">SCOREBOARD</text>
+  <text class="t" x="416" y="366">Every view, order, print and return, keyed to the design.</text>
+  <text class="t" x="416" y="383">Shown to every Inventor.</text>
+
+  <!-- loop arrows -->
+  <path class="loop" d="M1065 270 C 1065 359, 850 359, 820 359" marker-end="url(#arrowsoft)"/>
+  <path class="loop" d="M400 359 C 360 359, 155 359, 155 270" marker-end="url(#arrowsoft)"/>
+</svg>

--- a/docs/images/workshop-floorplan.svg
+++ b/docs/images/workshop-floorplan.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 2050" role="img" aria-labelledby="title description">
-  <title id="title">A peek inside the Autonomous Workshop: how a Wish becomes a toy</title>
-  <desc id="description">A journey from Wish into a pluggable agentic runtime, where one root coding-agent session acts as Workshop Manager. A durable private checkpoint resumes that exact session across stages, with per-command caps of three consecutive unfinished native turns or two consecutive recoverable native failures, explicit operator resumes, and supported in-place CLI updates. Each active stage attempt receives one native Codex Goal whose stopping condition is successful stage finalization. Each new run freezes one effort route: Spark goes through Make and Release, Forge goes through Invent, Make, and Release, and Quest adds Playtest before Release. New Codex Spark runs freeze low reasoning effort, a 64k automatic compaction ceiling, and a 20-minute boundary per native turn. New Forge and Quest Invent starts high for 20 minutes, ranks a compact complete-roster Taste index before opening the best three full agents, and uses a 10-minute medium source handoff that finalizes existing source first or writes then finalizes before refinement. Deep Make starts with one 16-minute medium proof runway: one bounded mandatory read, immediate source authoring, three exact product states, and a fixed-camera state sheet using a private run cache while the broad CAD skill is deferred. Visually indistinguishable states fail; proof recovery seals current fresh evidence before new design work. Root inspection checks this early direction; final Make retains independent blind critique. A checkpoint-bound liveness marker resumes the same Make Goal at high reasoning for a 15-minute source handoff before normal 30-minute recovery. Later stages use medium, all deep stages compact at 256k, and one command is capped at eight turns. The marker is not a gate or stage transition. None of these economics profiles weakens product gates. Make's fixed preflight generates every printable and requires strict fit, mesh validity, and 0.4 mm-nozzle thickness. Evidence-bound failures can return Make to Invent, or Quest Playtest directly to Make or Invent, within one shared revision budget. Inventor selection happens inside the first creative stage rather than in a separate Match turn. Release creates one initial and one final manual review packet before handing off to Operations for Printing, Deliver, and customer Review.</desc>
+  <title id="title">A peek inside the Autonomous Workshop: how an Inventor's idea becomes a toy</title>
+  <desc id="description">A journey from an Inventor's daydream, a concept card written by an autonomous AI Inventor that reads, researches and keeps a notebook around the clock, into a pluggable agentic runtime, where one root coding-agent session acts as Workshop Manager. A durable private checkpoint resumes that exact session across stages, with per-command caps of three consecutive unfinished native turns or two consecutive recoverable native failures, explicit operator resumes, and supported in-place CLI updates. Each active stage attempt receives one native Codex Goal whose stopping condition is successful stage finalization. Each new run freezes one effort route: Spark goes through Make and Release, Forge goes through Invent, Make, and Release, and Quest adds Playtest before Release. New Codex Spark runs freeze low reasoning effort, a 64k automatic compaction ceiling, and a 20-minute boundary per native turn. New Forge and Quest Invent starts high for 20 minutes, ranks a compact complete-roster Taste index before opening the best three full agents, and uses a 10-minute medium source handoff that finalizes existing source first or writes then finalizes before refinement. Deep Make starts with one 16-minute medium proof runway: one bounded mandatory read, immediate source authoring, three exact product states, and a fixed-camera state sheet using a private run cache while the broad CAD skill is deferred. Visually indistinguishable states fail; proof recovery seals current fresh evidence before new design work. Root inspection checks this early direction; final Make retains independent blind critique. A checkpoint-bound liveness marker resumes the same Make Goal at high reasoning for a 15-minute source handoff before normal 30-minute recovery. Later stages use medium, all deep stages compact at 256k, and one command is capped at eight turns. The marker is not a gate or stage transition. None of these economics profiles weakens product gates. Make's fixed preflight generates every printable and requires strict fit, mesh validity, and 0.4 mm-nozzle thickness. Evidence-bound failures can return Make to Invent, or Quest Playtest directly to Make or Invent, within one shared revision budget. Inventor selection happens inside the first creative stage rather than in a separate Match turn. Release creates one initial and one final manual review packet before handing off to Operations for Printing, Deliver, and customer Review.</desc>
 
   <defs>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="160%">
@@ -49,7 +49,7 @@
   </defs>
 
   <rect width="1000" height="2050" rx="28" fill="#f5f2ec"/>
-  <text x="50" y="65" class="title">A peek inside the Autonomous Workshop: how a Wish becomes a toy</text>
+  <text x="50" y="65" class="title">A peek inside the Autonomous Workshop: how an Inventor's idea becomes a toy</text>
 
   <g transform="translate(55 112)">
     <g>
@@ -93,16 +93,16 @@
     <text x="898" y="1170" text-anchor="middle" class="edge-label-human">PLAYERS SAY</text>
     <text x="898" y="1193" text-anchor="middle" class="body">what they loved</text>
     <text x="898" y="1214" text-anchor="middle" class="body">what surprised them</text>
-    <text x="898" y="1235" text-anchor="middle" class="body">what they wish for next</text>
+    <text x="898" y="1235" text-anchor="middle" class="body">what they buy next</text>
   </g>
 
-  <!-- Wish -->
+  <!-- Daydream -->
   <g filter="url(#shadow)">
     <rect class="node" x="220" y="170" width="560" height="110" rx="20"/>
   </g>
-  <text x="250" y="198" class="eyebrow">YOU IMAGINE IT</text>
-  <text x="250" y="230" class="heading">WISH</text>
-  <text x="250" y="256" class="body">Say what you want, in your own words.</text>
+  <text x="250" y="198" class="eyebrow">ALWAYS ON · EVERY INVENTOR</text>
+  <text x="250" y="230" class="heading">DAYDREAM</text>
+  <text x="250" y="256" class="body">Inventors read, research, learn and watch; keep a notebook; leave with one idea they like.</text>
 
   <!-- Workshop Manager / agentic runtime -->
   <g filter="url(#shadow)">
@@ -228,6 +228,6 @@
   <text x="250" y="1910" class="heading">REVIEW</text>
   <text x="250" y="1936" class="body">What you say helps this toy grow—and starts the next adventure.</text>
 
-  <text x="500" y="2010" text-anchor="middle" class="subtitle">One Wish in. One never-before-seen toy out.</text>
+  <text x="500" y="2010" text-anchor="middle" class="subtitle">One idea in. One never-before-seen toy out.</text>
 
 </svg>


### PR DESCRIPTION
# Pull request

## Outcome

Readers of the repo see the current direction: autonomous AI Inventors that daydream, invent, and make toys and games around the clock, sold printed to order in the shop. The consumer Wish page is gone from the README; Daydream is shown as the first stage in every diagram.

## Ownership

- Owning component: repository documentation
- Primary DRI: founder
- Backup or second reviewer: docs maintainer
- Risk: standard

## Change class

- [x] Documentation, governance, CI, packaging, or release

## Current and resulting behavior

Before:

- README led with the Wish page and price tiers; diagrams started at a Wish box.

After:

- README leads with the Inventors and the shop, adds a Direction section (Daydream in development, shop not wish page, Release explains the model, real photos on first order, outcome scoreboard), and keeps `workshop wish` documented as the current CLI entry point.
- New `docs/images/inventor-loop.svg`; floorplan and the Spark, Forge, and Quest route diagrams relabeled so the first box is Daydream.
- `.gitignore` excludes the private planning folders.

Explicitly out of scope:

- Any code, CLI, schema, or Inventor change. Daydream is not implemented here.

## Boundaries and contracts

- Public contract added or changed: none
- Components consuming it: none
- Dependency direction: unchanged
- External ports or effects: none
- Durable formats read or written: none

- [x] The change stays in its owning source and mirrored test directories.
- [x] Components import public contracts, not sibling private implementations.
- [x] Workflow remains the only stage sequencer.
- [x] Product work remains one persistent native session per Wish and one active Codex Goal per cognitive stage attempt; Python does not own the improvement loop.
- [x] CLI and inventor code depend on Workshop; Workshop does not import them.
- [x] No new `core`, `foundation`, `common`, or `utils` dumping ground was added.

## Verification

```text
git diff --check main..HEAD   # clean
qlmanage -t docs/images/*.svg  # all five diagrams rendered and reviewed; no clipped labels
```

- [x] `git diff --check`

## Compatibility and release note

- [x] No changelog required; reason: README and diagram text only, no runtime behavior.
- Breaking Python API: none
- Durable compatibility impact: none
- Migration or deprecation window: n/a

## Reviewer guide

Read the README Direction section first, then open `docs/images/inventor-loop.svg`. The one judgment call is keeping the internal Wish name visible in the quickstart so the docs match the CLI as it exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UDqwYvbGfvRxDwPg84j4k
