### PR TITLE
feat(cli): connect each Inventor to an Autonomous account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 **/*.bak.*
 **/state/portal-auth.json
 **/state/panda-auth.json
+# Host credentials stay ignored even when WORKSHOP_HOME points inside a checkout.
+**/credentials/inventors/*.env*
+**/credentials/factory.env*
 
 # generated runtime state
 .runtime/

--- a/README.md
+++ b/README.md
@@ -36,14 +36,9 @@ codex login
 uv run workshop doctor
 ```
 
-Every Inventor publishes to the shop as its own account, so a toy is credited to the Inventor that dreamed it. Create that account once at [autonomous.ai/toys](https://www.autonomous.ai/toys), using the Inventor's id as its name, then store it on this host:
+When an Inventor is not yet connected, Workshop opens [Connect Inventor](https://www.autonomous.ai/toys/inventor/login) during `create` or `start`. Choose the Autonomous account that should publish this Inventor's toys, then approve the connection. Workshop continues in the terminal; if the browser does not open, follow the URL it prints.
 
-```bash
-uv run workshop login pico-press                      # asks for the username and password
-echo "$PASSWORD" | uv run workshop login pico-press --username pico-press
-```
-
-Credentials live in `$WORKSHOP_HOME/credentials/inventors/<id>.env`, owner-readable, never inside a run workspace and never given to an agent. The first `workshop start` for an Inventor asks for them too when it is run in a terminal.
+Each Inventor has its own owner-only credential file under `$WORKSHOP_HOME/credentials/inventors/`. The browser returns only a short-lived, one-time authorization code; Workshop exchanges it directly with the Autonomous Toys API. Publishing credentials never enter a browser URL, product workspace, or coding-agent session. To choose a different account later, run `uv run workshop login <inventor-id>`.
 
 One command runs the whole loop, and keeps running it. Pico Press daydreams one brand-new idea that fits its Taste, the host rejects anything too close to a toy already made, the survivor is sealed as the brief, the run makes and publishes it (✨ Spark, `Make -> Release`, with Codex as the Workshop Manager; the idea is already the concept), and then Pico Press dreams the next one:
 
@@ -286,7 +281,7 @@ tests/              component-mirrored deterministic suite
 docs/               architecture, ADRs, and contributor guides
 ```
 
-Private state stays outside the agent-visible checkout: `$WORKSHOP_HOME/daydreams/<inventor>/`, `$WORKSHOP_HOME/runs/<wish-id>/workspace`, and `$WORKSHOP_HOME/state/<wish-id>/`. Factory credentials live in `$WORKSHOP_HOME/credentials/factory.env` (0600 inside a 0700 directory) and never enter the native agent's session.
+Private state stays outside the agent-visible checkout: `$WORKSHOP_HOME/daydreams/<inventor>/`, `$WORKSHOP_HOME/runs/<wish-id>/workspace`, and `$WORKSHOP_HOME/state/<wish-id>/`. Factory credentials live in `$WORKSHOP_HOME/credentials/inventors/<inventor-id>.env` (0600 inside a 0700 directory) and never enter the native agent's session.
 
 Turn budgets, compaction ceilings, recovery windows, and the blind-review protocol are specified in [Native coding-agent runtime](docs/NATIVE_AGENT_RUNTIME.md). See also [Workshop architecture](docs/ARCHITECTURE.md), the [publication boundary](docs/PUBLISH_SEALED_PRODUCT.md), and [Playtest evidence](docs/PLAYTEST_EVIDENCE.md).
 

--- a/changes/inventor-shop-accounts.added.md
+++ b/changes/inventor-shop-accounts.added.md
@@ -1,12 +1,13 @@
-- Give every Inventor its own shop account. `workshop start <inventor-id>`
-  now checks for that account before it dreams anything, prompts once for the
-  username and password, and stores them in
+- Give every Inventor its own shop account. The first time you create or start
+  an Inventor, Workshop opens
+  `https://www.autonomous.ai/toys/inventor/login` in your browser. Choose an
+  Autonomous account and approve **Connect Inventor**; Workshop then continues
+  in the terminal.
+- Store the generated publishing credential and canonical Inventor id in
   `$WORKSHOP_HOME/credentials/inventors/<id>.env` (0600 inside a 0700
-  directory, never inside a run workspace and never given to an agent).
-  Release resolves the publishing pair for the run's selected Inventor and
-  falls back to the host-wide file, so existing hosts keep publishing.
-- `workshop login <inventor-id>` stores that account: it prompts in a
-  terminal and reads the password from stdin when one is piped, so a password
-  never reaches shell history or the process table.
-- `workshop create inventor` prints the sign-up link and the next command.
-  `WORKSHOP_SHOP_SIGNUP_URL` overrides the link.
+  directory). The browser redirects a short-lived authorization code to the
+  local callback; Workshop exchanges it directly with the API using PKCE. The
+  publishing credential never enters browser JavaScript, a URL, a run
+  workspace, or a coding-agent process.
+- `workshop login <inventor-id>` repeats the browser flow to choose a different
+  account. Existing host-wide Factory credentials remain supported.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -455,10 +455,13 @@ on that mutable ordering. Draft and public evidence are accepted only when
 authenticated readback preserves the declared category slug.
 
 Starting `workshop wish` authorizes this one required publication for the exact
-run bytes; there is no separate publish mode. One host-owned Workshop Factory
-service account publishes every Inventor's Release. Its credentials are stored
-outside the run in the private Workshop home, loaded only between native turns,
-and never copied into the run workspace or coding-agent process. Inventor
+run bytes; there is no separate publish mode. The person authorizes Workshop in
+the browser, and the Autonomous Toys API generates a reusable publishing
+credential for that account. It is stored outside the run in the private
+Workshop home under the Inventor id that was created or started.
+Release loads only that Inventor's file between native turns and uses the
+existing Factory login integration to mint a 365-day bearer in memory. Neither
+credential enters the run workspace or coding-agent process. Inventor
 provenance stays in the sealed Release facts rather than being inferred from
 the publisher username. Missing credentials leave Release incomplete. A public
 page is the terminal digital handoff, never a printing or delivery receipt.

--- a/docs/BUILD_AN_INVENTOR.md
+++ b/docs/BUILD_AN_INVENTOR.md
@@ -78,6 +78,11 @@ uv run workshop create inventor ada \
   --root .
 ```
 
+Before writing the bundle, Workshop opens
+`https://www.autonomous.ai/toys/inventor/login` so you can choose the account
+that will publish this Inventor's toys. That connection is stored for this
+Inventor on this computer only.
+
 `inventor.json` records only stable source metadata and exact skill-tree
 bindings:
 

--- a/docs/NATIVE_AGENT_RUNTIME.md
+++ b/docs/NATIVE_AGENT_RUNTIME.md
@@ -18,7 +18,8 @@ Workshop. It is authoritative together with
 [ADR 0037](adr/0037-raise-deep-compaction-ceiling.md),
 [ADR 0038](adr/0038-prove-product-states-and-bound-final-source.md),
 [ADR 0039](adr/0039-make-invent-recovery-a-source-handoff.md),
-[ADR 0040](adr/0040-make-proof-recovery-a-sealing-handoff.md), and the repository
+[ADR 0040](adr/0040-make-proof-recovery-a-sealing-handoff.md),
+[ADR 0042](adr/0042-browser-issued-factory-credential.md), and the repository
 [agent instructions](../AGENTS.md). ADR 0013 supersedes ADR 0012's page-first
 Release details; ADR 0014 supersedes their optional-publication and
 executable-Deliver details; ADR 0016 supersedes ADR 0015's one fixed route.
@@ -672,11 +673,19 @@ thickness-checked, print-ready CAD, validates the exact `MANUAL.pdf`, imports
 the exact CAD/manual handoff, publishes it, and verifies public page and manual
 readback hashes. Missing credentials or a remote outage leaves Release waiting
 and resumable; the durable effect ledger reconciles before retry. Local
-credentials belong in the private `$WORKSHOP_HOME/credentials/factory.env`
-file and are loaded lazily only after the native turn exits. One Workshop-owned
-Factory service account publishes every Inventor's Release; Inventor provenance
-remains independently sealed in the product facts and never selects
-credentials. Codex 0.145.0 or newer runs with Workshop's strict
+credentials belong in private
+`$WORKSHOP_HOME/credentials/inventors/<inventor-id>.env` files and are loaded
+lazily only after the native turn exits. Interactive hosts store the publishing
+credential issued by the Autonomous Toys API against the Inventor named by
+explicit browser authorization. The existing Factory session exchanges that
+credential for a 365-day bearer only when Release needs it and keeps the bearer
+in memory. Browser authorization uses a short-lived, single-use code and PKCE;
+the website performs a top-level redirect to the loopback callback, and the CLI
+exchanges the code directly with the Autonomous Toys API. Inventor provenance
+remains independently sealed in the product facts
+and selects only the matching host credential file, whose embedded Inventor id
+must also match.
+Codex 0.145.0 or newer runs with Workshop's strict
 permission profile: all filesystem reads are denied by default, the exact
 absolute toy project is writable, immutable instructions remain read-only,
 only minimal tool paths plus the identity-bound Workshop Python runtime and

--- a/docs/PUBLISH_SEALED_PRODUCT.md
+++ b/docs/PUBLISH_SEALED_PRODUCT.md
@@ -73,19 +73,27 @@ it.
 
 ## Credentials
 
-Supply Factory credentials through the private
-`$WORKSHOP_HOME/credentials/factory.env` file (preferred) or a supported
-ephemeral host environment or secret manager. The trusted host loads them only
-when no native agent turn is running. Never put credentials in a Wish, prompt,
-`TASTE.md`, product-run workspace, Release package, source file, or commit. The
-coding-agent subprocess receives a scrubbed environment.
+Interactive users do not create Factory credentials by hand. The first
+`workshop create inventor` or `workshop start <inventor-id>` opens
+`https://www.autonomous.ai/toys/inventor/login`; `workshop login <inventor-id>`
+reconnects explicitly. The trusted host writes the result to the matching
+owner-only `$WORKSHOP_HOME/credentials/inventors/<inventor-id>.env` file and
+loads it only when no native agent turn is running.
 
-The private file uses strict `NAME=raw-value` lines; it is not evaluated by a
-shell, so literal surrounding single or double quotes are invalid. Configure
-exactly one Workshop service account with `FACTORY_USERNAME` and
-`FACTORY_PASSWORD`. This account publishes every Release regardless of which
-Inventor the first active creative stage selected; a person running
-`workshop wish` never supplies a Factory username or password.
+Never put credentials in a Wish, prompt, `TASTE.md`, product-run workspace,
+Release package, source file, or commit. The coding-agent subprocess receives a
+scrubbed environment. Ephemeral host environments and secret managers remain
+supported for non-interactive and legacy deployments.
+
+Each private file uses strict `NAME=raw-value` lines; it is not evaluated by a
+shell, so literal surrounding single or double quotes are invalid. After the
+user authorizes Workshop for the named Inventor, the website redirects only a
+five-minute, single-use authorization code to the loopback callback. Workshop
+proves its in-memory PKCE verifier directly to the Autonomous Toys API, which
+returns `FACTORY_USERNAME` and `FACTORY_PASSWORD` exactly once to the CLI. The
+publishing credential never enters browser JavaScript or a URL. The file also
+stores `FACTORY_INVENTOR_ID`; a missing or mismatched binding is rejected before
+Release.
 
 For migration, exactly one legacy scoped username such as
 `FACTORY_ALICE_USERNAME=alice` is temporarily accepted with
@@ -94,17 +102,19 @@ to that Inventor. Multiple scoped usernames, or a generic and scoped username
 together, are rejected as ambiguous. Rename the legacy key to
 `FACTORY_USERNAME`.
 
-Run `uv run workshop doctor` to validate account singularity, pair
-completeness, file permissions, and syntax without printing any secret value.
-At login, the returned Factory username must match the configured service
-account. Authenticated owner ids and exact artifact hashes remain bound through
-import, publication, reconciliation, and readback receipts. Missing or rejected
+`uv run workshop doctor` validates any legacy host-wide configuration without
+printing a secret. `create` and `start` validate the selected Inventor's file
+before using it. At import, the unchanged Factory session calls
+`/auth/agent/login` with the stored pair, keeps the returned 365-day bearer in
+memory, and retries that login once after a protected request returns `401`.
+Authenticated owner ids and exact artifact hashes remain bound through import,
+publication, reconciliation, and readback receipts. Missing or rejected
 credentials leave Release waiting with a concrete need; they do not create a
 successful private-only Release.
 
-Factory may display the Workshop service account as the public author. The
-actual Inventor remains independently bound in the sealed product facts; it is
-not inferred from the Factory login identity.
+Factory displays the authorizing account as the public author. The actual
+Inventor remains independently bound in the sealed product facts; it is not
+inferred from the Factory login identity.
 
 ## Recovery
 

--- a/docs/adr/0042-browser-issued-factory-credential.md
+++ b/docs/adr/0042-browser-issued-factory-credential.md
@@ -1,0 +1,47 @@
+# ADR 0042: Connect each Inventor through browser authorization
+
+- Status: Accepted
+- Date: 2026-09-03
+- Owners: Workshop CLI, Autonomous website, Autonomous Toys API
+
+## Decision
+
+- Give every Inventor its own shop account.
+- First `create` or `start` without a credential opens
+  `https://www.autonomous.ai/toys/inventor/login`.
+- `workshop login <inventor-id>` reconnects or switches the account.
+- Signed-out users sign in. Signed-in users confirm the active account or use
+  **Use another account**.
+- CLI creates random state, an in-memory PKCE verifier/challenge, and a one-shot
+  `127.0.0.1` callback.
+- Website asks the API for a five-minute, single-use authorization code, then
+  navigates the browser to the callback with only `code` and `state`.
+- Website never fetches, probes, or posts credentials to the loopback address.
+- CLI verifies state and exchanges `code` plus the PKCE verifier directly with
+  the API. The generated username and password are returned only to the CLI.
+- Store username, password, and Inventor id in
+  `$WORKSHOP_HOME/credentials/inventors/<inventor-id>.env`; directory `0700`,
+  file `0600`, atomic replacement.
+- Release uses the stored pair with `/auth/agent/login` and keeps its bearer in
+  memory.
+- No publishing credential in browser JavaScript, URLs, product workspaces,
+  agent environments, artifacts, logs, or receipts.
+- Existing host-wide credentials remain compatibility-only.
+- Deploy API, then website, then Workshop CLI.
+
+## Result
+
+- Standard browser-to-CLI redirect; no public-page request into the local
+  network and no Chrome local-network permission prompt.
+- Intercepted codes are short-lived, single-use, and unusable without the PKCE
+  verifier.
+- Publication remains a host-owned effect.
+
+## Verification
+
+- State, PKCE, purpose separation, expiry, replay, redirect validation, and
+  malformed-response tests.
+- Private-file permissions, Inventor binding, API login, and bounded re-login
+  tests.
+- CLI create/start/login tests and browser QA for signed-in, signed-out, and
+  account-switch flows.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -12,14 +12,17 @@ the installed `workshop` command.
 Spark is the default. Status and resume read that durable choice rather than
 accepting a new effort value.
 
-`workshop login <inventor-id>` stores that Inventor's shop account: it prompts
-in a terminal and reads the password from stdin when one is piped, so a
-password never reaches shell history or the process table. `workshop start
-<inventor-id>` refuses to begin without that account and prompts for it when
-it is interactive. Both write
-`$WORKSHOP_HOME/credentials/inventors/<id>.env` (owner-only). Release then publishes as that account, so the shop credits the
-Inventor that dreamed the toy. `WORKSHOP_SHOP_SIGNUP_URL` overrides the
-sign-up link the CLI prints.
+`workshop create inventor` and the first `workshop start <inventor-id>` open
+`https://www.autonomous.ai/toys/inventor/login` when that Inventor is not yet
+connected. The CLI prints the complete authorization URL, opens the browser,
+and waits on a random-state, one-shot loopback callback. The callback receives
+only a short-lived code; the CLI exchanges it directly with the Autonomous Toys
+API using its in-memory PKCE verifier. It stores the generated Factory
+username/password and canonical Inventor id in the owner-only
+`$WORKSHOP_HOME/credentials/inventors/<inventor-id>.env`. The stored id must
+match the Inventor selected for publication. The publishing credential never
+enters browser JavaScript, a URL, run workspace, or native-agent environment.
+`workshop login <inventor-id>` explicitly repeats the same flow.
 
 `workshop start <inventor-id>` is the front door and a loop: it asks one
 Inventor to dream one brand-new idea through `workshop.daydream`, prints the

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import getpass
 import hashlib
 import json
 import os
@@ -52,12 +51,12 @@ from workshop.make.skill_registry import (
     resolve_skills_root,
 )
 from workshop.runtime.agent_assets import product_run_agent_assets
+from workshop.runtime.browser_login import FactoryBrowserLogin
 from workshop.runtime.execution import codex_subprocess_environment
 from workshop.runtime.credentials import (
-    inventor_credential_file,
-    store_factory_credentials,
     factory_credential_environment,
     factory_service_credential_environment,
+    store_factory_credentials,
 )
 from workshop.runtime.codex import (
     MINIMUM_CODEX_NATIVE_RUNTIME_VERSION,
@@ -86,83 +85,74 @@ from workshop.workflow.effort import (
 
 
 _INVENTOR_ID_PART = re.compile(r"[^a-z0-9]+")
-_DEFAULT_SHOP_SIGNUP_URL = "https://www.autonomous.ai/toys"
-
-
-def _shop_signup_url() -> str:
-    """Where a person creates an Inventor's shop account.
-
-    The site has no dedicated signup route yet, so this points at the shop and
-    stays overridable; the site team can move it without a code change.
-    """
-
-    configured = os.environ.get("WORKSHOP_SHOP_SIGNUP_URL", "").strip()
-    return configured or _DEFAULT_SHOP_SIGNUP_URL
 
 
 def _publishing_account_ready(inventor_id: str) -> bool:
-    """Whether this Inventor already has its own shop account on this host."""
+    """Whether one Inventor has a complete generated Factory credential."""
 
-    scoped = inventor_credential_file(inventor_id)
-    if not (scoped.exists() or scoped.is_symlink()) and not (
-        os.environ.get("FACTORY_USERNAME") and os.environ.get("FACTORY_PASSWORD")
-    ):
-        return False
     try:
-        pair = factory_service_credential_environment(
+        credential = factory_service_credential_environment(
             factory_credential_environment(inventor_id=inventor_id)
         )
     except WorkshopError:
         return False
-    return bool(pair.get("FACTORY_USERNAME")) and bool(pair.get("FACTORY_PASSWORD"))
+    return bool(credential.get("FACTORY_USERNAME")) and bool(
+        credential.get("FACTORY_PASSWORD")
+    )
+
+
+def _browser_login(inventor_id: str, progress: TextIO) -> Path:
+    """Connect one Inventor and persist its generated Factory credential."""
+
+    if not sys.stdin.isatty():
+        raise WorkshopError(
+            "Workshop is not signed in and cannot open an interactive browser from "
+            "this terminal. Run `%s` in an interactive terminal first."
+            % _shell_command("workshop", "login", inventor_id)
+        )
+    with FactoryBrowserLogin(inventor_id=inventor_id) as login:
+        print(
+            "Connect %s to Autonomous" % inventor_id,
+            file=progress,
+            flush=True,
+        )
+        print("Open this link in your browser:", file=progress, flush=True)
+        print(login.authorization_url, file=progress, flush=True)
+        login.open_browser()
+        print("Waiting for authorization...", file=progress, flush=True)
+        credential = login.wait()
+    path = store_factory_credentials(
+        credential.username,
+        credential.password,
+        inventor_id=inventor_id,
+    )
+    print(
+        "Connected %s to @%s." % (inventor_id, credential.username),
+        file=progress,
+        flush=True,
+    )
+    print(
+        "Credentials: %s (owner-only)" % path,
+        file=progress,
+        flush=True,
+    )
+    return path
 
 
 def _ensure_publishing_account(inventor_id: str, progress: TextIO) -> None:
-    """Ask for this Inventor's shop account before any work is started.
-
-    Each Inventor publishes as itself, so the shop credits the Inventor that
-    dreamed the toy. Release ends only after the Factory publishes and reads
-    the exact hashes back, so a run without an account would dream, build, and
-    then fail at the last step. Ask first, store the pair owner-only, and never
-    let it near an agent workspace.
-    """
+    """Require browser-issued publishing credentials for one Inventor."""
 
     if _publishing_account_ready(inventor_id):
         return
-    signup = "Create one at %s, then run this again." % _shop_signup_url()
-    if not sys.stdin.isatty():
-        raise WorkshopError(
-            "%s has no shop account on this host, and this is not a terminal. "
-            "Store one with %s, or pipe the password in with "
-            "`echo <password> | workshop login %s --username <name>`. %s"
-            % (
-                inventor_id,
-                _shell_command("workshop", "login", inventor_id),
-                inventor_id,
-                signup,
-            )
-        )
     print(
-        "%s publishes to the shop as its own account, and this host does not "
-        "have it yet." % inventor_id,
+        "Inventor %s needs your Autonomous account to publish finished toys."
+        % inventor_id,
         file=progress,
         flush=True,
     )
-    print(
-        "Create an account for %s at %s, then enter it here."
-        % (inventor_id, _shop_signup_url()),
-        file=progress,
-        flush=True,
-    )
-    try:
-        username = input("Shop username for %s: " % inventor_id).strip()
-        password = getpass.getpass("Shop password for %s: " % inventor_id).strip()
-    except EOFError as exc:
-        raise WorkshopError("no account was entered for %s. %s" % (inventor_id, signup)) from exc
-    if not username or not password:
-        raise WorkshopError("both a username and a password are required")
-    path = store_factory_credentials(username, password, inventor_id=inventor_id)
-    print("Saved %s's account to %s (owner-only)." % (inventor_id, path), file=progress, flush=True)
+    _browser_login(inventor_id, progress)
+
+
 _LIVE_ACTIVE_INTERVAL_SECONDS = 2.0
 _LIVE_RUNNING_INTERVAL_SECONDS = 30.0
 _LIVE_CHURN_ACTIVITY = frozenset(("reasoning", "tool", "subagent"))
@@ -310,6 +300,16 @@ def _validated_inventors(root: Path):
     collection = inventor_collection(root)
     validate_inventor_collection(collection)
     return tuple(discover_inventors(collection))
+
+
+def _require_routable_inventor(root: Path, inventor_id: str) -> None:
+    """Reject an unknown or invalid Inventor before any browser authorization."""
+
+    collection = inventor_collection(root)
+    validate_inventor_collection(
+        collection,
+        required_routable_id=inventor_id,
+    )
 
 
 def _inventor_problems(manifests) -> list[str]:
@@ -596,33 +596,10 @@ def _dream_or_load(
 
 
 def _login(args: argparse.Namespace) -> int:
-    """Store one Inventor's shop account, interactively or from a pipe."""
+    """Explicitly start the same browser authorization used by create/start."""
 
-    inventor_id = args.inventor
-    username = (args.username or "").strip()
-    interactive = sys.stdin.isatty()
-    if not username:
-        if not interactive:
-            raise WorkshopError(
-                "--username is required when the password is piped in"
-            )
-        print(
-            "Create %s's account at %s if it does not exist yet."
-            % (inventor_id, _shop_signup_url())
-        )
-        username = input("Shop username for %s: " % inventor_id).strip()
-    if interactive:
-        password = getpass.getpass("Shop password for %s: " % inventor_id).strip()
-    else:
-        # A pipe is the only way to pass a password without putting it in shell
-        # history or the process table.
-        password = sys.stdin.readline().strip()
-    if not username or not password:
-        raise WorkshopError("both a username and a password are required")
-    path = store_factory_credentials(username, password, inventor_id=inventor_id)
-    print("Stored %s's shop account as %s." % (inventor_id, username))
-    print("Credentials: %s (owner-only)" % path)
-    print("Next: %s" % _shell_command("workshop", "start", inventor_id))
+    _browser_login(args.inventor, sys.stdout)
+    print("Next: %s" % _shell_command("workshop", "start", args.inventor))
     return 0
 
 
@@ -659,6 +636,7 @@ def _start(args: argparse.Namespace) -> int:
         raise WorkshopError("--max-ideas must be at least 1")
     if args.max_failures < 1:
         raise WorkshopError("--max-failures must be at least 1")
+    _require_routable_inventor(root, args.inventor)
     _ensure_publishing_account(args.inventor, progress)
     lease = acquire_loop(args.inventor)
     if not once:
@@ -1036,17 +1014,8 @@ def _doctor_factory() -> dict[str, str]:
     if not username and not password:
         return _check_record(
             "factory-credentials",
-            "needs-attention",
-            (
-                "Factory credentials are not configured; Release requires public "
-                "Factory publication."
-            ),
-            next_step=(
-                "Configure the Workshop service account as FACTORY_USERNAME and "
-                "FACTORY_PASSWORD in the private "
-                "$WORKSHOP_HOME/credentials/factory.env file; Wish users do not "
-                "supply Factory credentials."
-            ),
+            "ready",
+            "Each Inventor connects to Autonomous in the browser when first needed.",
         )
     return _check_record(
         "factory-credentials",
@@ -1189,7 +1158,6 @@ def _inventors(args: argparse.Namespace) -> int:
 
 
 def _create_inventor(args: argparse.Namespace) -> int:
-    collection = prepare_inventor_collection(args.root)
     if args.taste is None and not args.inventor_id:
         raise WorkshopError(
             "inventor_id is required unless --taste supplies a TASTE.md name"
@@ -1200,6 +1168,9 @@ def _create_inventor(args: argparse.Namespace) -> int:
     name = args.name
     if args.taste is None and name is None:
         name = _default_inventor_name(inventor_id)
+    collection = prepare_inventor_collection(args.root)
+    progress = sys.stderr if args.json else sys.stdout
+    _ensure_publishing_account(inventor_id, progress)
     destination = create_inventor(
         collection,
         inventor_id,
@@ -1235,15 +1206,7 @@ def _create_inventor(args: argparse.Namespace) -> int:
         print("Taste: %s" % (destination / "TASTE.md"))
         print("Skill: %s" % (destination / manifest.extensions[0].path / "SKILL.md"))
         print("Checks: static-passed")
-        print(
-            "Next: create %s's shop account at %s so its toys are published "
-            "under its own name." % (manifest.inventor_id, _shop_signup_url())
-        )
-        print(
-            "Then: %s asks for that username and password once and stores them "
-            "on this host only."
-            % _shell_command("workshop", "start", manifest.inventor_id)
-        )
+        print("Next: %s" % _shell_command("workshop", "start", manifest.inventor_id))
     return 0
 
 
@@ -1468,16 +1431,12 @@ def parser() -> argparse.ArgumentParser:
 
     login = subcommands.add_parser(
         "login",
-        help="store one Inventor's shop account so its toys publish under its name",
+        help="connect one Inventor to your Autonomous account in a browser",
     )
-    login.add_argument("inventor", metavar="INVENTOR")
     login.add_argument(
-        "--username",
-        metavar="NAME",
-        help=(
-            "the Inventor's shop username; required when the password is piped "
-            "in rather than typed"
-        ),
+        "inventor",
+        metavar="INVENTOR",
+        help="Inventor id to connect, such as pico-press",
     )
     login.set_defaults(handler=_login)
 

--- a/src/workshop/integrations/README.md
+++ b/src/workshop/integrations/README.md
@@ -2,10 +2,12 @@
 
 Owns the authenticated Factory adapter used for the host-effect portion of
 Release. `factory.py` builds an exact sealed model-and-Release ZIP handoff,
-logs in with Workshop's single host-owned Factory service account, carries the
-canonical `MANUAL.pdf`, and proves public publication by authenticated hash
-readback. The selected Inventor remains sealed product provenance and is not
-the Factory authentication identity.
+uses the selected Inventor's host-only generated Factory username/password,
+carries the canonical `MANUAL.pdf`, and proves public publication by
+authenticated hash readback. The existing session exchanges the pair for a
+365-day bearer and keeps it in memory only. The selected Inventor remains
+sealed product provenance and selects a local credential file; it is not the
+Factory authentication identity.
 The local product, full-tier print-ready CAD, and in-box manual must pass their
 deterministic gates before this effect starts, but Release remains incomplete
 until Factory readback verifies the exact public bytes. Unsupported remote

--- a/src/workshop/runtime/browser_login.py
+++ b/src/workshop/runtime/browser_login.py
@@ -270,7 +270,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             self._respond(
                 200,
                 "Inventor connected",
-                "You're all set. Workshop is continuing in your terminal.",
+                "You can close this window and continue in your terminal.",
             )
         finally:
             self.server.completed.set()

--- a/src/workshop/runtime/browser_login.py
+++ b/src/workshop/runtime/browser_login.py
@@ -1,0 +1,429 @@
+"""PKCE browser authorization for a host-owned Factory credential.
+
+The browser returns only a short-lived, single-use authorization code through a
+normal top-level redirect to the loopback listener. Workshop proves possession
+of the in-memory PKCE verifier directly to the Factory API; the generated
+username/password pair never passes through browser JavaScript or a URL.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import html
+import json
+import os
+import re
+import secrets
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable, Optional
+
+from workshop.errors import WorkshopError
+
+
+DEFAULT_INVENTOR_LOGIN_URL = "https://www.autonomous.ai/toys/inventor/login"
+DEFAULT_CREDENTIAL_EXCHANGE_URL = (
+    "https://panda-social-api.autonomous.ai/api/v1/"
+    "auth/agent-credentials/exchange"
+)
+INVENTOR_LOGIN_URL_ENV = "WORKSHOP_INVENTOR_LOGIN_URL"
+LOGIN_CALLBACK_PATH = "/callback"
+LOGIN_TIMEOUT_SECONDS = 5 * 60
+HTTP_TIMEOUT_SECONDS = 30
+MAX_EXCHANGE_RESPONSE_BYTES = 64 * 1024
+_AUTHORIZATION_CODE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_INVENTOR_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def _bounded_secret(value: object, label: str, maximum: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > maximum
+        or any(ord(character) < 33 or ord(character) == 127 for character in value)
+    ):
+        raise WorkshopError("%s is missing or malformed" % label)
+    return value
+
+
+@dataclass(frozen=True, repr=False)
+class BrowserLoginCredential:
+    """Validated Factory values returned directly to Workshop."""
+
+    username: str
+    password: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "username",
+            _bounded_secret(self.username, "Factory username", 512),
+        )
+        object.__setattr__(
+            self,
+            "password",
+            _bounded_secret(self.password, "Factory password", 4096),
+        )
+
+    def __repr__(self) -> str:
+        return "BrowserLoginCredential(<redacted>)"
+
+
+CodeExchanger = Callable[[str, str], BrowserLoginCredential]
+BrowserOpener = Callable[[str], bool]
+
+
+def _exchange_authorization_code(
+    code: str,
+    code_verifier: str,
+    *,
+    exchange_url: str = DEFAULT_CREDENTIAL_EXCHANGE_URL,
+) -> BrowserLoginCredential:
+    body = json.dumps(
+        {"code": code, "code_verifier": code_verifier},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        exchange_url,
+        data=body,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "AutonomousWorkshop/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            if response.status != 200:
+                raise WorkshopError("Workshop authorization exchange was rejected")
+            source = response.read(MAX_EXCHANGE_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        raise WorkshopError("Workshop authorization exchange was rejected") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise WorkshopError(
+            "Workshop could not reach the Autonomous account service"
+        ) from exc
+    if len(source) > MAX_EXCHANGE_RESPONSE_BYTES:
+        raise WorkshopError("Workshop authorization response was too large")
+    try:
+        value = json.loads(source.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise WorkshopError("Workshop authorization response was malformed") from exc
+    if not isinstance(value, dict):
+        raise WorkshopError("Workshop authorization response was malformed")
+    return BrowserLoginCredential(
+        username=value.get("username"),
+        password=value.get("password"),
+    )
+
+
+class _LoopbackServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        address,
+        handler,
+        *,
+        expected_state: str,
+        exchange_code: Callable[[str], BrowserLoginCredential],
+    ):
+        super().__init__(address, handler)
+        self.expected_state = expected_state
+        self.exchange_code = exchange_code
+        self.credential: Optional[BrowserLoginCredential] = None
+        self.failure: Optional[str] = None
+        self.claimed = False
+        self.completed = threading.Event()
+        self.result_lock = threading.Lock()
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    server: _LoopbackServer
+    server_version = "AutonomousWorkshop"
+    sys_version = ""
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def _respond(self, status: int, title: str, message: str) -> None:
+        status_class = "success" if status < 400 else "error"
+        status_icon = "✓" if status < 400 else "!"
+        document = (
+            '<!doctype html><html><head><meta charset="utf-8">'
+            '<meta name="viewport" content="width=device-width">'
+            '<meta http-equiv="Content-Security-Policy" '
+            'content="default-src \'none\'; style-src \'unsafe-inline\'">'
+            '<meta name="referrer" content="no-referrer">'
+            "<title>%s</title>"
+            "<style>"
+            "*{box-sizing:border-box}body{margin:0;background:#f3f3ef;color:#191a17;"
+            "font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}"
+            "main{min-height:100vh;display:grid;place-items:center;padding:24px}"
+            "section{width:min(460px,100%%);padding:40px;border:1px solid #dcddd7;"
+            "border-radius:18px;background:#fffffd;box-shadow:0 24px 70px "
+            "rgba(20,22,18,.1);text-align:center}"
+            "i{display:grid;width:48px;height:48px;margin:0 auto 20px;"
+            "place-items:center;border-radius:50%%;background:#ddf5e8;color:#23734b;"
+            "font-size:22px;font-style:normal;font-weight:700}"
+            "i.error{background:#fbe4e2;color:#a72d27}"
+            "h1{margin:0 0 10px;font-size:30px;letter-spacing:-.03em}"
+            "p{margin:0;color:#62645e;line-height:1.55}"
+            '</style></head><body><main><section><i class="%s">%s</i>'
+            "<h1>%s</h1><p>%s</p>"
+            "</section></main></body></html>"
+        ) % tuple(
+            html.escape(value)
+            for value in (title, status_class, status_icon, title, message)
+        )
+        body = document.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _is_callback_target(self) -> bool:
+        expected_host = "127.0.0.1:%d" % self.server.server_address[1]
+        parsed = urllib.parse.urlsplit(self.path)
+        return (
+            parsed.path == LOGIN_CALLBACK_PATH
+            and not parsed.fragment
+            and self.headers.get("Host") == expected_host
+        )
+
+    def _callback_code(self) -> Optional[str]:
+        try:
+            values = urllib.parse.parse_qs(
+                urllib.parse.urlsplit(self.path).query,
+                keep_blank_values=True,
+                strict_parsing=True,
+                max_num_fields=2,
+            )
+            state = values.get("state", [])
+            code = values.get("code", [])
+            if (
+                set(values) != {"code", "state"}
+                or len(state) != 1
+                or not hmac.compare_digest(state[0], self.server.expected_state)
+                or len(code) != 1
+                or _AUTHORIZATION_CODE.fullmatch(code[0]) is None
+            ):
+                return None
+            return code[0]
+        except (UnicodeError, ValueError):
+            return None
+
+    def do_GET(self) -> None:
+        if not self._is_callback_target():
+            self._respond(
+                404,
+                "Connection not found",
+                "Return to the terminal and start the connection again.",
+            )
+            return
+        code = self._callback_code()
+        if code is None:
+            self._respond(
+                400,
+                "Connection could not be verified",
+                "Return to the terminal and start the connection again.",
+            )
+            return
+        with self.server.result_lock:
+            if self.server.claimed or self.server.completed.is_set():
+                self._respond(
+                    409,
+                    "Connection already completed",
+                    "You can close this tab and continue in the terminal.",
+                )
+                return
+            self.server.claimed = True
+        try:
+            credential = self.server.exchange_code(code)
+        except WorkshopError as exc:
+            self.server.failure = str(exc)
+            try:
+                self._respond(
+                    502,
+                    "Connection did not finish",
+                    "Return to the terminal for details, then try again.",
+                )
+            finally:
+                self.server.completed.set()
+            return
+        self.server.credential = credential
+        try:
+            self._respond(
+                200,
+                "Inventor connected",
+                "You're all set. Workshop is continuing in your terminal.",
+            )
+        finally:
+            self.server.completed.set()
+
+    def do_POST(self) -> None:
+        self._respond(
+            405,
+            "Connection method not allowed",
+            "Return to the terminal and start the connection again.",
+        )
+
+    def do_OPTIONS(self) -> None:
+        self._respond(
+            405,
+            "Connection method not allowed",
+            "Return to the terminal and start the connection again.",
+        )
+
+
+class FactoryBrowserLogin:
+    """One PKCE browser authorization backed by a loopback callback."""
+
+    def __init__(
+        self,
+        *,
+        inventor_id: str,
+        login_url: Optional[str] = None,
+        opener: BrowserOpener = webbrowser.open,
+        exchanger: CodeExchanger = _exchange_authorization_code,
+    ) -> None:
+        if (
+            not isinstance(inventor_id, str)
+            or _INVENTOR_ID.fullmatch(inventor_id) is None
+        ):
+            raise WorkshopError("Inventor id must be a canonical slug")
+        configured_login_url = os.environ.get(INVENTOR_LOGIN_URL_ENV)
+        if login_url is None:
+            login_url = configured_login_url or DEFAULT_INVENTOR_LOGIN_URL
+        parsed = urllib.parse.urlsplit(login_url)
+        if (
+            parsed.scheme not in ("http", "https")
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise WorkshopError("Inventor login URL is malformed")
+        if parsed.scheme != "https" and parsed.hostname not in (
+            "localhost",
+            "127.0.0.1",
+        ):
+            raise WorkshopError("Inventor login URL must use HTTPS")
+        if (
+            configured_login_url
+            and login_url == configured_login_url
+            and parsed.hostname not in ("localhost", "127.0.0.1")
+        ):
+            raise WorkshopError(
+                "%s may only target localhost" % INVENTOR_LOGIN_URL_ENV
+            )
+        self._login_url = login_url
+        self._inventor_id = inventor_id
+        self._opener = opener
+        self._exchanger = exchanger
+        self._state = secrets.token_urlsafe(32)
+        self._code_verifier = secrets.token_urlsafe(32)
+        self._code_challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(self._code_verifier.encode("ascii")).digest()
+        ).rstrip(b"=").decode("ascii")
+        self._server: Optional[_LoopbackServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def __enter__(self) -> "FactoryBrowserLogin":
+        try:
+            self._server = _LoopbackServer(
+                ("127.0.0.1", 0),
+                _CallbackHandler,
+                expected_state=self._state,
+                exchange_code=lambda code: self._exchanger(
+                    code, self._code_verifier
+                ),
+            )
+        except OSError as exc:
+            raise WorkshopError(
+                "Workshop could not start the local login callback"
+            ) from exc
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="workshop-login-callback",
+            daemon=True,
+        )
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+
+    @property
+    def authorization_url(self) -> str:
+        if self._server is None:
+            raise WorkshopError("Workshop login callback is not running")
+        callback_url = "http://127.0.0.1:%d%s" % (
+            self._server.server_address[1],
+            LOGIN_CALLBACK_PATH,
+        )
+        query = urllib.parse.urlencode(
+            {
+                "callback_url": callback_url,
+                "state": self._state,
+                "inventor_id": self._inventor_id,
+                "code_challenge": self._code_challenge,
+                "code_challenge_method": "S256",
+            }
+        )
+        return self._login_url + "?" + query
+
+    def open_browser(self) -> bool:
+        try:
+            return bool(self._opener(self.authorization_url))
+        except Exception:
+            return False
+
+    def wait(
+        self, timeout_seconds: int = LOGIN_TIMEOUT_SECONDS
+    ) -> BrowserLoginCredential:
+        if (
+            self._server is None
+            or type(timeout_seconds) is not int
+            or timeout_seconds <= 0
+        ):
+            raise WorkshopError("Workshop login wait is not configured")
+        if not self._server.completed.wait(timeout_seconds):
+            raise WorkshopError(
+                "Browser login timed out after %d minutes"
+                % (timeout_seconds // 60)
+            )
+        if self._server.failure is not None:
+            raise WorkshopError(self._server.failure)
+        if self._server.credential is None:
+            raise WorkshopError("Browser login did not return a credential")
+        return self._server.credential
+
+
+__all__ = [
+    "BrowserLoginCredential",
+    "DEFAULT_CREDENTIAL_EXCHANGE_URL",
+    "DEFAULT_INVENTOR_LOGIN_URL",
+    "FactoryBrowserLogin",
+    "INVENTOR_LOGIN_URL_ENV",
+    "LOGIN_TIMEOUT_SECONDS",
+]

--- a/src/workshop/runtime/credentials.py
+++ b/src/workshop/runtime/credentials.py
@@ -1,6 +1,7 @@
 """Host-only credential loading outside every product-run workspace.
 
-The preferred local source is ``$WORKSHOP_HOME/credentials/factory.env``.
+Browser-issued credentials are stored per Inventor under
+``$WORKSHOP_HOME/credentials/inventors/``.
 It is read lazily by the trusted host after a native coding-agent turn exits;
 the file path and values are never passed to that subprocess.
 """
@@ -19,7 +20,8 @@ from workshop.runtime.package_data import default_workshop_home
 
 MAX_FACTORY_CREDENTIAL_FILE_BYTES = 32 * 1024
 _FACTORY_CREDENTIAL_NAME = re.compile(
-    r"^FACTORY_(?:PASSWORD|USERNAME|[A-Z][A-Z0-9_]{0,63}_USERNAME)$"
+    r"^FACTORY_(?:INVENTOR_ID|PASSWORD|USERNAME|"
+    r"[A-Z][A-Z0-9_]{0,63}_USERNAME)$"
 )
 _FACTORY_SCOPED_USERNAME_NAME = re.compile(
     r"^FACTORY_([A-Z][A-Z0-9_]{0,63})_USERNAME$"
@@ -154,7 +156,7 @@ def _parse_credential_file(
         if (
             not value
             or value != value.strip()
-            or len(value.encode("utf-8")) > 4096
+            or len(value.encode("utf-8")) > 16_384
             or any(ord(character) < 32 or ord(character) == 127 for character in value)
         ):
             raise ContractError(
@@ -186,11 +188,7 @@ def inventor_credential_file(
     inventor_id: str,
     environment: Optional[Mapping[str, str]] = None,
 ) -> Path:
-    """Return one Inventor's own publishing account file.
-
-    Each Inventor publishes as itself, so its account lives in its own
-    owner-only file rather than sharing the host-wide pair.
-    """
+    """Return one per-Inventor publishing-account file."""
 
     if not isinstance(inventor_id, str) or _FACTORY_INVENTOR_ID.fullmatch(inventor_id) is None:
         raise ContractError("Inventor id must be a canonical slug")
@@ -207,19 +205,15 @@ def factory_credential_environment(
 ) -> Mapping[str, str]:
     """Load bounded Factory values without exposing unrelated environment data.
 
-    ``inventor_id`` selects that Inventor's own account file when it exists and
-    falls back to the host-wide file, so a host that has not yet given every
-    Inventor an account keeps publishing. Explicit process environment values
-    override both for ephemeral and CI hosts. Product-run Codex receives none
-    of these sources through :func:`codex_subprocess_environment`.
+    ``inventor_id`` selects that Inventor's credential file when it exists and
+    falls back to the legacy host-wide username/password pair. Explicit process
+    environment values override disk for ephemeral and CI hosts. Product-run
+    Codex receives none of these sources through
+    :func:`codex_subprocess_environment`.
     """
 
     values = os.environ if environment is None else environment
     path = factory_credential_file(values)
-    if inventor_id is not None:
-        scoped = inventor_credential_file(inventor_id, values)
-        if scoped.exists() or scoped.is_symlink():
-            path = scoped
     loaded: dict[str, str] = {}
     if path.exists() or path.is_symlink():
         loaded.update(
@@ -229,6 +223,18 @@ def factory_credential_environment(
                 label="Factory",
             )
         )
+    if inventor_id is not None:
+        scoped = inventor_credential_file(inventor_id, values)
+        if scoped.exists() or scoped.is_symlink():
+            loaded = _parse_credential_file(
+                _read_private_credential_file(scoped),
+                _FACTORY_CREDENTIAL_NAME,
+                label="Factory",
+            )
+            if loaded.get("FACTORY_INVENTOR_ID") != inventor_id:
+                raise ContractError(
+                    "Factory credential is not bound to Inventor %s" % inventor_id
+                )
     environment_values = _credential_environment_values(values)
     environment_usernames = {
         name
@@ -246,21 +252,35 @@ def factory_credential_environment(
             ):
                 loaded.pop(name)
     loaded.update(environment_values)
+    bound_inventor_id = loaded.get("FACTORY_INVENTOR_ID")
+    if (
+        inventor_id is not None
+        and bound_inventor_id is not None
+        and bound_inventor_id != inventor_id
+    ):
+        raise ContractError(
+            "Factory credential is not bound to Inventor %s" % inventor_id
+        )
     return loaded
 
 
 def validate_factory_credential_configuration(values: Mapping[str, str]) -> None:
     """Validate one host credential set without returning or exposing secrets.
 
-    The canonical configuration is one Workshop-owned service account under
-    ``FACTORY_USERNAME`` and ``FACTORY_PASSWORD``. Exactly one legacy scoped
-    username is accepted temporarily as an unambiguous compatibility alias;
-    it is normalized to the same single service account and never binds
-    publication authority to the selected Inventor.
+    Browser authorization stores one generated Factory username/password pair
+    plus its Inventor binding. One scoped username alias remains accepted for
+    legacy hosts.
     """
 
     if not isinstance(values, Mapping):
         raise ContractError("Factory credential configuration must be a mapping")
+
+    bound_inventor_id = values.get("FACTORY_INVENTOR_ID")
+    if bound_inventor_id is not None and (
+        not isinstance(bound_inventor_id, str)
+        or _FACTORY_INVENTOR_ID.fullmatch(bound_inventor_id) is None
+    ):
+        raise ContractError("Factory credential inventor id is malformed")
 
     usernames_present = False
     generic_username = values.get("FACTORY_USERNAME")
@@ -318,6 +338,10 @@ def validate_factory_credential_configuration(values: Mapping[str, str]) -> None
             "Factory credentials must define only one Workshop service account; "
             "replace legacy scoped username variables with FACTORY_USERNAME"
         )
+    if bound_inventor_id is not None and generic_username is None:
+        raise ContractError(
+            "Factory credential inventor id requires FACTORY_USERNAME"
+        )
 
     password = values.get("FACTORY_PASSWORD")
     password_present = password is not None
@@ -344,28 +368,8 @@ def validate_factory_credential_configuration(values: Mapping[str, str]) -> None
         )
 
 
-def store_factory_credentials(
-    username: str,
-    password: str,
-    *,
-    inventor_id: Optional[str] = None,
-    environment: Optional[Mapping[str, str]] = None,
-) -> Path:
-    """Write one validated Factory service-account pair to the private file.
-
-    The file is the operator's own credential store: 0600 inside a 0700
-    directory, never inside a run workspace and never given to an agent.  An
-    existing file is replaced atomically so a failed write cannot leave a
-    half-written credential behind.
-    """
-
-    values = {"FACTORY_USERNAME": username, "FACTORY_PASSWORD": password}
+def _store_factory_values(values: Mapping[str, str], path: Path) -> Path:
     validate_factory_credential_configuration(values)
-    path = (
-        factory_credential_file(environment)
-        if inventor_id is None
-        else inventor_credential_file(inventor_id, environment)
-    )
     directory = path.parent
     try:
         directory.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -392,14 +396,41 @@ def store_factory_credentials(
     return path
 
 
+def store_factory_credentials(
+    username: str,
+    password: str,
+    *,
+    inventor_id: Optional[str] = None,
+    environment: Optional[Mapping[str, str]] = None,
+) -> Path:
+    """Write one validated Factory service-account pair to the private file.
+
+    The file is the operator's own credential store: 0600 inside a 0700
+    directory, never inside a run workspace and never given to an agent.  An
+    existing file is replaced atomically so a failed write cannot leave a
+    half-written credential behind.
+    """
+
+    values = {"FACTORY_USERNAME": username, "FACTORY_PASSWORD": password}
+    if inventor_id is not None:
+        values["FACTORY_INVENTOR_ID"] = inventor_id
+    path = (
+        factory_credential_file(environment)
+        if inventor_id is None
+        else inventor_credential_file(inventor_id, environment)
+    )
+    return _store_factory_values(values, path)
+
+
 def factory_service_credential_environment(
     values: Mapping[str, str],
 ) -> Mapping[str, str]:
-    """Normalize one validated Workshop Factory service-account pair.
+    """Normalize one validated Workshop Factory username/password pair.
 
-    A single legacy ``FACTORY_<INVENTOR>_USERNAME`` value is accepted only so
-    existing private hosts can migrate without interrupting Release. Its
-    variable name grants no Inventor-scoped authority.
+    The Inventor binding is validated at the file boundary and deliberately
+    omitted from the service mapping consumed by the unchanged Factory login
+    integration. A single legacy ``FACTORY_<INVENTOR>_USERNAME`` value remains
+    accepted for migration.
     """
 
     validate_factory_credential_configuration(values)

--- a/src/workshop/workflow/native_run.py
+++ b/src/workshop/workflow/native_run.py
@@ -277,8 +277,8 @@ _RECOVERABLE_BACKOFF_MAX_SECONDS = 30.0
 _RECOVERABLE_BACKOFF_JITTER_MIN = 0.75
 _RECOVERABLE_BACKOFF_JITTER_SPAN = 0.5
 _FACTORY_CREDENTIALS_NEED = (
-    "Factory credentials for Workshop's service account are missing or malformed; "
-    "configure FACTORY_USERNAME and FACTORY_PASSWORD, then resume this run."
+    "Factory credentials for Workshop publication are missing or malformed; run "
+    "`workshop login <inventor-id>` in an interactive terminal, then resume this run."
 )
 _FACTORY_PUBLICATION_NEED = (
     "Factory publication could not be verified; restore server connectivity, "

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -12,6 +12,7 @@ from unittest import mock
 
 from cli.main import main, parser
 from workshop.runtime.progress import WishRunTimingEvent
+from workshop.runtime.browser_login import BrowserLoginCredential
 from workshop.daydream import DaydreamError
 
 from tests.daydream.support import sample_sealed
@@ -497,6 +498,9 @@ class DaydreamCommandTest(unittest.TestCase):
         environment.start()
         self.addCleanup(environment.stop)
         self._with_credentials()
+        routing = mock.patch("cli.main._require_routable_inventor")
+        routing.start()
+        self.addCleanup(routing.stop)
 
     def _loop_folder(self):
         return self.home / "daydreams" / "sample"
@@ -877,33 +881,35 @@ class DaydreamCommandTest(unittest.TestCase):
         self.assertEqual(signals, [True])
         self.assertIn("Interrupting the daydream loop for sample", stdout.getvalue())
 
-    def test_start_asks_for_this_inventors_shop_account_before_any_work(self):
+    def test_start_opens_browser_login_before_any_work_when_credential_is_missing(self):
         mock.patch.stopall()
         environment = mock.patch.dict(os.environ, {"WORKSHOP_HOME": str(self.home)})
         environment.start()
         self.addCleanup(environment.stop)
         stdout = StringIO()
-        with mock.patch("cli.main.sys.stdin.isatty", return_value=True), mock.patch(
-            "builtins.input", return_value=" pico-press "
+        with mock.patch(
+            "cli.main._publishing_account_ready", return_value=False
         ), mock.patch(
-            "cli.main.getpass.getpass", return_value="s3cret"
+            "cli.main._require_routable_inventor"
         ), mock.patch(
+            "cli.main._browser_login",
+            return_value=self.home / "credentials" / "inventors" / "sample.env",
+        ) as login, mock.patch(
             "cli.main.run_daydream", return_value=sample_sealed()
         ) as run, mock.patch(
             "cli.main.start_native_run", return_value=native_receipt()
         ), redirect_stdout(stdout), redirect_stderr(StringIO()):
             result = main(("start", "sample", "--once"))
         self.assertEqual(result, 0)
+        login.assert_called_once_with("sample", stdout)
         run.assert_called_once()
         output = stdout.getvalue()
-        self.assertIn("sample publishes to the shop as its own account", output)
-        self.assertIn("https://www.autonomous.ai/toys", output)
-        stored = self.home / "credentials" / "inventors" / "sample.env"
-        self.assertEqual(stat.S_IMODE(stored.stat().st_mode), 0o600)
-        self.assertIn("FACTORY_USERNAME=pico-press", stored.read_text(encoding="utf-8"))
-        # A second start reuses the stored pair and never prompts again.
-        with mock.patch(
-            "builtins.input", side_effect=AssertionError("prompted twice")
+        self.assertIn("needs your Autonomous account", output)
+        # A second start reuses the stored credential and never opens a browser.
+        with mock.patch("cli.main._publishing_account_ready", return_value=True), mock.patch(
+            "cli.main._require_routable_inventor"
+        ), mock.patch(
+            "cli.main._browser_login", side_effect=AssertionError("opened twice")
         ), mock.patch(
             "cli.main.run_daydream", return_value=sample_sealed()
         ), mock.patch(
@@ -911,13 +917,17 @@ class DaydreamCommandTest(unittest.TestCase):
         ), redirect_stdout(StringIO()), redirect_stderr(StringIO()):
             self.assertEqual(main(("start", "sample", "--once")), 0)
 
-    def test_start_without_an_account_outside_a_terminal_fails_closed(self):
+    def test_start_without_a_credential_outside_a_terminal_fails_closed(self):
         mock.patch.stopall()
         environment = mock.patch.dict(os.environ, {"WORKSHOP_HOME": str(self.home)})
         environment.start()
         self.addCleanup(environment.stop)
         stderr = StringIO()
-        with mock.patch("cli.main.sys.stdin.isatty", return_value=False), mock.patch(
+        with mock.patch(
+            "cli.main._publishing_account_ready", return_value=False
+        ), mock.patch(
+            "cli.main._require_routable_inventor"
+        ), mock.patch("cli.main.sys.stdin.isatty", return_value=False), mock.patch(
             "cli.main.run_daydream"
         ) as run, mock.patch("cli.main.acquire_loop") as lease, redirect_stdout(
             StringIO()
@@ -926,49 +936,40 @@ class DaydreamCommandTest(unittest.TestCase):
         self.assertEqual(result, 2)
         run.assert_not_called()
         lease.assert_not_called()
-        self.assertIn("sample has no shop account on this host", stderr.getvalue())
-        self.assertIn("https://www.autonomous.ai/toys", stderr.getvalue())
+        self.assertIn("workshop login", stderr.getvalue())
 
-    def test_login_stores_an_account_from_a_pipe_and_from_a_terminal(self):
+    def test_login_opens_browser_and_stores_the_generated_credential(self):
         mock.patch.stopall()
         environment = mock.patch.dict(os.environ, {"WORKSHOP_HOME": str(self.home)})
         environment.start()
         self.addCleanup(environment.stop)
+        credential = BrowserLoginCredential(
+            username="khoa",
+            password="generated-agent-secret",
+        )
+        flow = mock.MagicMock()
+        flow.authorization_url = (
+            "https://www.autonomous.ai/toys/inventor/login?callback_url=local&state=random"
+        )
+        flow.open_browser.return_value = True
+        flow.wait.return_value = credential
+        context = mock.MagicMock()
+        context.__enter__.return_value = flow
         stdout = StringIO()
-        with mock.patch("cli.main.sys.stdin.isatty", return_value=False), mock.patch(
-            "cli.main.sys.stdin.readline", return_value="piped-secret\n"
+        with mock.patch("cli.main.sys.stdin.isatty", return_value=True), mock.patch(
+            "cli.main.FactoryBrowserLogin", return_value=context
         ), redirect_stdout(stdout), redirect_stderr(StringIO()):
-            result = main(("login", "sample", "--username", "sample"))
+            result = main(("login", "sample"))
         self.assertEqual(result, 0)
         stored = self.home / "credentials" / "inventors" / "sample.env"
         self.assertEqual(stat.S_IMODE(stored.stat().st_mode), 0o600)
         body = stored.read_text(encoding="utf-8")
-        self.assertIn("FACTORY_USERNAME=sample", body)
-        self.assertIn("FACTORY_PASSWORD=piped-secret", body)
-        self.assertNotIn("piped-secret", stdout.getvalue())
-        self.assertIn("Stored sample's shop account as sample.", stdout.getvalue())
-
-        with mock.patch("cli.main.sys.stdin.isatty", return_value=True), mock.patch(
-            "builtins.input", return_value="typed-name"
-        ), mock.patch(
-            "cli.main.getpass.getpass", return_value="typed-secret"
-        ), redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-            self.assertEqual(main(("login", "sample")), 0)
-        body = stored.read_text(encoding="utf-8")
-        self.assertIn("FACTORY_USERNAME=typed-name", body)
-        self.assertIn("FACTORY_PASSWORD=typed-secret", body)
-
-    def test_login_from_a_pipe_requires_a_username(self):
-        mock.patch.stopall()
-        environment = mock.patch.dict(os.environ, {"WORKSHOP_HOME": str(self.home)})
-        environment.start()
-        self.addCleanup(environment.stop)
-        stderr = StringIO()
-        with mock.patch("cli.main.sys.stdin.isatty", return_value=False), redirect_stdout(
-            StringIO()
-        ), redirect_stderr(stderr):
-            self.assertEqual(main(("login", "sample")), 2)
-        self.assertIn("--username is required", stderr.getvalue())
+        self.assertIn("FACTORY_USERNAME=khoa", body)
+        self.assertIn("FACTORY_PASSWORD=generated-agent-secret", body)
+        self.assertIn("FACTORY_INVENTOR_ID=sample", body)
+        self.assertNotIn("generated-agent-secret", stdout.getvalue())
+        self.assertIn("Connected sample to @khoa.", stdout.getvalue())
+        self.assertIn("workshop start sample", stdout.getvalue())
 
     def test_daydream_failure_reports_on_stderr_with_exit_two(self):
         stderr = StringIO()
@@ -993,6 +994,21 @@ class DaydreamCommandTest(unittest.TestCase):
             self.assertEqual(result, 2)
             run.assert_not_called()
             self.assertIn("no native Inventor bundles", stderr.getvalue())
+
+    def test_unknown_inventor_fails_before_browser_login(self):
+        mock.patch.stopall()
+        stderr = StringIO()
+        with mock.patch("cli.main._browser_login") as login, mock.patch(
+            "cli.main.run_daydream"
+        ) as run, redirect_stdout(StringIO()), redirect_stderr(stderr):
+            result = main(("start", "test-inventor2", "--once"))
+        self.assertEqual(result, 2)
+        login.assert_not_called()
+        run.assert_not_called()
+        self.assertIn(
+            "inventor collection is missing test-inventor2",
+            stderr.getvalue(),
+        )
 
 
 class DoctorTest(unittest.TestCase):
@@ -1041,7 +1057,7 @@ class DoctorTest(unittest.TestCase):
         self.assertIn("goals, subagents, and isolation", check["detail"])
         self.assertIn("0.145.0", check["next"])
 
-    def test_missing_factory_credentials_block_terminal_release(self):
+    def test_missing_factory_credentials_are_created_on_demand(self):
         ready = lambda name: {"name": name, "status": "ready", "detail": "ok"}
         stdout = StringIO()
         with mock.patch.dict(os.environ, {}, clear=True), mock.patch(
@@ -1055,11 +1071,11 @@ class DoctorTest(unittest.TestCase):
         ), redirect_stdout(stdout):
             result = main(("doctor", "--json"))
         receipt = json.loads(stdout.getvalue())
-        self.assertEqual(result, 1)
-        self.assertEqual(receipt["status"], "needs-attention")
+        self.assertEqual(result, 0)
+        self.assertEqual(receipt["status"], "ready")
         factory = next(item for item in receipt["checks"] if item["name"] == "factory-credentials")
-        self.assertEqual(factory["status"], "needs-attention")
-        self.assertIn("Release requires public Factory publication", factory["detail"])
+        self.assertEqual(factory["status"], "ready")
+        self.assertIn("connects to Autonomous", factory["detail"])
 
     def test_partial_factory_credentials_fail_without_printing_values(self):
         secret = "do-not-print-this-value"
@@ -1142,6 +1158,11 @@ class DoctorTest(unittest.TestCase):
 
 
 class PersonaCommandTest(unittest.TestCase):
+    def setUp(self):
+        ready = mock.patch("cli.main._publishing_account_ready", return_value=True)
+        ready.start()
+        self.addCleanup(ready.stop)
+
     def test_create_list_and_check_use_only_v8_inventor_bundles(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1221,6 +1242,76 @@ class PersonaCommandTest(unittest.TestCase):
                 (root / "inventors" / "moon-weaver" / "TASTE.md").read_bytes(),
                 content,
             )
+
+    def test_create_inventor_starts_browser_login_when_needed(self):
+        with tempfile.TemporaryDirectory() as temporary, mock.patch(
+            "cli.main._publishing_account_ready", return_value=False
+        ), mock.patch("cli.main._browser_login") as login, redirect_stdout(
+            StringIO()
+        ), redirect_stderr(StringIO()):
+            self.assertEqual(
+                main(
+                    (
+                        "create",
+                        "inventor",
+                        "mira",
+                        "--description",
+                        "kinetic desk toys",
+                        "--root",
+                        temporary,
+                    )
+                ),
+                0,
+            )
+        login.assert_called_once_with("mira", mock.ANY)
+
+    def test_create_inventor_validates_root_before_browser_login(self):
+        with tempfile.TemporaryDirectory() as temporary, mock.patch(
+            "cli.main._publishing_account_ready", return_value=False
+        ), mock.patch("cli.main._browser_login") as login, redirect_stdout(
+            StringIO()
+        ), redirect_stderr(StringIO()):
+            self.assertEqual(
+                main(
+                    (
+                        "create",
+                        "inventor",
+                        "mira",
+                        "--description",
+                        "kinetic desk toys",
+                        "--root",
+                        str(Path(temporary) / "missing"),
+                    )
+                ),
+                2,
+            )
+        login.assert_not_called()
+
+    def test_create_json_keeps_browser_login_progress_off_stdout(self):
+        with tempfile.TemporaryDirectory() as temporary, mock.patch(
+            "cli.main._publishing_account_ready", return_value=False
+        ), mock.patch("cli.main._browser_login") as login:
+            stdout = StringIO()
+            stderr = StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                self.assertEqual(
+                    main(
+                        (
+                            "create",
+                            "inventor",
+                            "mira",
+                            "--description",
+                            "kinetic desk toys",
+                            "--root",
+                            temporary,
+                            "--json",
+                        )
+                    ),
+                    0,
+                )
+        login.assert_called_once_with("mira", stderr)
+        self.assertEqual(json.loads(stdout.getvalue())["id"], "mira")
+        self.assertIn("needs your Autonomous account", stderr.getvalue())
 
     def test_check_rejects_pre_v8_manifests_without_executing_them(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/end_to_end/test_native_full_run.py
+++ b/tests/end_to_end/test_native_full_run.py
@@ -1374,14 +1374,14 @@ class _FactoryEffects:
         self.credentials_value = SimpleNamespace(
             username="alice", password=self.secret
         )
-        self.credential_requests = 0
+        self.credential_requests = []
         self.writer_calls = []
         self.session_calls = []
         self.publish_calls = []
         self.ledgers = []
 
-    def credentials(self):
-        self.credential_requests += 1
+    def credentials(self, inventor_id):
+        self.credential_requests.append(inventor_id)
         return self.credentials_value
 
     def writer(self, ledger, inventor_id, credentials):
@@ -3186,7 +3186,7 @@ class NativeFullRunTest(unittest.TestCase):
                 )
                 self.assertEqual(made.product["title"], "Orbit Dog Draughts")
 
-            self.assertEqual(effects.credential_requests, 1)
+            self.assertEqual(effects.credential_requests, ["alice"])
             self.assertEqual(len(effects.writer_calls), 2)
             self.assertIs(effects.writer_calls[0][2], effects.credentials_value)
             self.assertEqual(len(effects.ledgers), 1)

--- a/tests/integrations/test_factory.py
+++ b/tests/integrations/test_factory.py
@@ -549,7 +549,10 @@ class FactoryReleaseTest(unittest.TestCase):
         self.assertEqual(receipt.adapter, "factory")
         self.assertEqual(receipt.details["release_sha256"], self.manifest.artifact_sha256)
         self.assertEqual(receipt.details["playtest_evidence_sha256"], self.playtest_sha256)
-        self.assertEqual(receipt.details["page_url"], "https://www.autonomous.ai/factory/product/verified-toy")
+        self.assertEqual(
+            receipt.details["page_url"],
+            "https://www.autonomous.ai/toys/product/verified-toy",
+        )
         self.assertEqual(receipt.details["primary_model_path"], "assembled.stl")
         self.assertEqual(
             receipt.details["factory_category_slug"],
@@ -1591,7 +1594,7 @@ def draft_receipt():
             ).hexdigest(),
             "factory_content": content,
             "factory_content_mapping": "workshop-release-v3-to-factory-content-v1",
-            "page_url": "https://www.autonomous.ai/factory/product/verified-toy",
+            "page_url": "https://www.autonomous.ai/toys/product/verified-toy",
         },
         design_id="design-1",
         slug="verified-toy",
@@ -1619,7 +1622,7 @@ def pdf_draft_receipt():
             "manual_path": "MANUAL.pdf",
             "manual_sha256": hashlib.sha256(PDF_MANUAL).hexdigest(),
             "factory_category_slug": FACTORY_TOY_CATEGORY_SLUG,
-            "page_url": "https://www.autonomous.ai/factory/product/verified-toy",
+            "page_url": "https://www.autonomous.ai/toys/product/verified-toy",
         },
         design_id="design-1",
         slug="verified-toy",

--- a/tests/packaging/installed_wheel_cli_acceptance.py
+++ b/tests/packaging/installed_wheel_cli_acceptance.py
@@ -911,6 +911,23 @@ def acceptance(
             token in wish_help for token in ("--effort", "spark", "forge", "quest")
         ):
             raise AssertionError("installed Wish help lacks selectable effort routes")
+        login_help = _run(
+            (workshop, "login", "--help"), cwd=away, environment=environment
+        ).stdout
+        if "INVENTOR" not in login_help or "--username" in login_help:
+            raise AssertionError("installed login help lacks the browser flow")
+        _run(
+            (
+                python,
+                "-c",
+                "from workshop.runtime.browser_login import "
+                "DEFAULT_INVENTOR_LOGIN_URL as url; "
+                "assert url == "
+                "'https://www.autonomous.ai/toys/inventor/login', url",
+            ),
+            cwd=away,
+            environment=environment,
+        )
         if with_dependencies:
             _native_wish_smoke(
                 workshop=workshop,

--- a/tests/runtime/test_browser_login.py
+++ b/tests/runtime/test_browser_login.py
@@ -87,6 +87,9 @@ class FactoryBrowserLoginTest(unittest.TestCase):
                 self.assertEqual(response.status, 200)
                 body = response.read().decode("utf-8")
                 self.assertIn("Inventor connected", body)
+                self.assertIn(
+                    "You can close this window and continue in your terminal.", body
+                )
                 self.assertNotIn(code, body)
                 self.assertNotIn("long-lived-agent-password", body)
                 self.assertEqual(response.headers["Cache-Control"], "no-store")

--- a/tests/runtime/test_browser_login.py
+++ b/tests/runtime/test_browser_login.py
@@ -1,0 +1,264 @@
+import base64
+import hashlib
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+import unittest
+from unittest import mock
+
+from workshop.errors import WorkshopError
+from workshop.runtime.browser_login import (
+    DEFAULT_CREDENTIAL_EXCHANGE_URL,
+    DEFAULT_INVENTOR_LOGIN_URL,
+    FactoryBrowserLogin,
+    INVENTOR_LOGIN_URL_ENV,
+    BrowserLoginCredential,
+    _exchange_authorization_code,
+)
+
+
+class _Response:
+    def __init__(self, body, status=200):
+        self.status = status
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return None
+
+    def read(self, _maximum):
+        return self._body
+
+
+class FactoryBrowserLoginTest(unittest.TestCase):
+    @staticmethod
+    def _callback_url(callback_url, state, code="a" * 43):
+        return callback_url + "?" + urllib.parse.urlencode(
+            {"code": code, "state": state}
+        )
+
+    @classmethod
+    def _get(cls, callback_url, state, code="a" * 43):
+        return urllib.request.urlopen(
+            cls._callback_url(callback_url, state, code),
+            timeout=2,
+        )
+
+    def test_browser_redirect_returns_code_and_cli_exchanges_with_pkce(self):
+        opened = []
+        exchanged = []
+
+        def exchange(code, verifier):
+            exchanged.append((code, verifier))
+            return BrowserLoginCredential(
+                username="khoa",
+                password="long-lived-agent-password",
+            )
+
+        login_url = "http://127.0.0.1:3000/toys/inventor/login"
+        with FactoryBrowserLogin(
+            inventor_id="pico-press",
+            login_url=login_url,
+            opener=lambda url: opened.append(url) or True,
+            exchanger=exchange,
+        ) as login:
+            authorization_url = login.authorization_url
+            parsed = urllib.parse.urlsplit(authorization_url)
+            query = urllib.parse.parse_qs(parsed.query)
+            callback_url = query["callback_url"][0]
+            state = query["state"][0]
+            challenge = query["code_challenge"][0]
+
+            self.assertEqual(parsed.path, "/toys/inventor/login")
+            self.assertEqual(query["inventor_id"], ["pico-press"])
+            self.assertEqual(query["code_challenge_method"], ["S256"])
+            self.assertEqual(len(challenge), 43)
+            self.assertNotIn("code_verifier", query)
+            self.assertTrue(callback_url.startswith("http://127.0.0.1:"))
+            self.assertTrue(login.open_browser())
+            self.assertEqual(opened, [authorization_url])
+
+            code = "b" * 43
+            with self._get(callback_url, state, code) as response:
+                self.assertEqual(response.status, 200)
+                body = response.read().decode("utf-8")
+                self.assertIn("Inventor connected", body)
+                self.assertNotIn(code, body)
+                self.assertNotIn("long-lived-agent-password", body)
+                self.assertEqual(response.headers["Cache-Control"], "no-store")
+                self.assertEqual(response.headers["Referrer-Policy"], "no-referrer")
+            credential = login.wait(timeout_seconds=1)
+
+        self.assertEqual(credential.username, "khoa")
+        self.assertEqual(credential.password, "long-lived-agent-password")
+        self.assertNotIn("long-lived-agent-password", repr(credential))
+        self.assertEqual(exchanged[0][0], code)
+        verifier = exchanged[0][1]
+        expected = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode("ascii")).digest()
+        ).rstrip(b"=").decode("ascii")
+        self.assertEqual(expected, challenge)
+        self.assertNotIn(verifier, authorization_url)
+
+    def test_wrong_state_and_malformed_code_do_not_consume_callback(self):
+        exchanged = []
+        login_url = "http://127.0.0.1:3000/toys/inventor/login"
+        with FactoryBrowserLogin(
+            inventor_id="pico-press",
+            login_url=login_url,
+            exchanger=lambda code, verifier: exchanged.append((code, verifier))
+            or BrowserLoginCredential("khoa", "valid-password"),
+        ) as login:
+            query = urllib.parse.parse_qs(
+                urllib.parse.urlsplit(login.authorization_url).query
+            )
+            callback_url = query["callback_url"][0]
+            state = query["state"][0]
+            with self.assertRaises(urllib.error.HTTPError) as wrong_state:
+                self._get(callback_url, "wrong-state")
+            self.assertEqual(wrong_state.exception.code, 400)
+            with self.assertRaises(urllib.error.HTTPError) as malformed_code:
+                self._get(callback_url, state, "not-a-valid-code")
+            self.assertEqual(malformed_code.exception.code, 400)
+            self.assertEqual(exchanged, [])
+
+            with self._get(callback_url, state):
+                pass
+            self.assertEqual(login.wait(timeout_seconds=1).username, "khoa")
+        self.assertEqual(len(exchanged), 1)
+
+    def test_post_and_wrong_path_do_not_consume_callback(self):
+        exchanged = []
+        with FactoryBrowserLogin(
+            inventor_id="pico-press",
+            login_url="http://127.0.0.1:3000/toys/inventor/login",
+            exchanger=lambda code, verifier: exchanged.append((code, verifier))
+            or BrowserLoginCredential("khoa", "valid-password"),
+        ) as login:
+            query = urllib.parse.parse_qs(
+                urllib.parse.urlsplit(login.authorization_url).query
+            )
+            callback_url = query["callback_url"][0]
+            state = query["state"][0]
+            with self.assertRaises(urllib.error.HTTPError) as wrong_path:
+                urllib.request.urlopen(
+                    self._callback_url(
+                        callback_url.replace("/callback", "/wrong"), state
+                    ),
+                    timeout=2,
+                )
+            self.assertEqual(wrong_path.exception.code, 404)
+            with self.assertRaises(urllib.error.HTTPError) as post:
+                urllib.request.urlopen(
+                    urllib.request.Request(
+                        callback_url,
+                        data=b"credential=must-not-be-accepted",
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+            self.assertEqual(post.exception.code, 405)
+            self.assertEqual(exchanged, [])
+            with self._get(callback_url, state):
+                pass
+            self.assertEqual(login.wait(timeout_seconds=1).username, "khoa")
+
+    def test_exchange_failure_is_reported_without_secret_response(self):
+        secret = "server-secret-must-not-render"
+
+        def rejected(_code, _verifier):
+            raise WorkshopError(secret)
+
+        with FactoryBrowserLogin(
+            inventor_id="pico-press",
+            login_url="http://127.0.0.1:3000/toys/inventor/login",
+            exchanger=rejected,
+        ) as login:
+            query = urllib.parse.parse_qs(
+                urllib.parse.urlsplit(login.authorization_url).query
+            )
+            with self.assertRaises(urllib.error.HTTPError) as callback:
+                self._get(query["callback_url"][0], query["state"][0])
+            self.assertEqual(callback.exception.code, 502)
+            self.assertNotIn(secret, callback.exception.read().decode("utf-8"))
+            with self.assertRaisesRegex(WorkshopError, secret):
+                login.wait(timeout_seconds=1)
+
+    def test_default_exchange_posts_code_and_verifier_to_factory_api(self):
+        sent = {}
+
+        def fake_urlopen(request, timeout):
+            sent["url"] = request.full_url
+            sent["body"] = request.data
+            sent["timeout"] = timeout
+            return _Response(
+                json.dumps(
+                    {"username": "khoa", "password": "generated-password"}
+                ).encode("utf-8")
+            )
+
+        with mock.patch(
+            "workshop.runtime.browser_login.urllib.request.urlopen",
+            side_effect=fake_urlopen,
+        ):
+            credential = _exchange_authorization_code("c" * 43, "d" * 43)
+
+        self.assertEqual(sent["url"], DEFAULT_CREDENTIAL_EXCHANGE_URL)
+        self.assertNotIn("c" * 43, sent["url"])
+        self.assertEqual(
+            json.loads(sent["body"]),
+            {"code": "c" * 43, "code_verifier": "d" * 43},
+        )
+        self.assertEqual(credential.username, "khoa")
+        self.assertEqual(credential.password, "generated-password")
+
+    def test_malformed_exchange_response_fails_closed(self):
+        with mock.patch(
+            "workshop.runtime.browser_login.urllib.request.urlopen",
+            return_value=_Response(b'{"username":"khoa"}'),
+        ):
+            with self.assertRaisesRegex(WorkshopError, "password"):
+                _exchange_authorization_code("c" * 43, "d" * 43)
+
+    def test_default_authorization_page_is_production_autonomous(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with FactoryBrowserLogin(
+                inventor_id="pico-press",
+                exchanger=lambda _code, _verifier: BrowserLoginCredential(
+                    "khoa", "password"
+                ),
+            ) as login:
+                parsed = urllib.parse.urlsplit(login.authorization_url)
+        production = urllib.parse.urlsplit(DEFAULT_INVENTOR_LOGIN_URL)
+        self.assertEqual(parsed.scheme, "https")
+        self.assertEqual(parsed.netloc, production.netloc)
+        self.assertEqual(parsed.path, "/toys/inventor/login")
+
+    def test_environment_can_override_login_page_for_local_development(self):
+        local_url = "http://localhost:3000/de-DE/toys/inventor/login"
+        with mock.patch.dict(os.environ, {INVENTOR_LOGIN_URL_ENV: local_url}):
+            with FactoryBrowserLogin(
+                inventor_id="pico-press",
+                opener=lambda _url: False,
+            ) as login:
+                self.assertTrue(login.authorization_url.startswith(local_url + "?"))
+
+    def test_environment_cannot_override_login_page_with_remote_host(self):
+        with mock.patch.dict(
+            os.environ,
+            {INVENTOR_LOGIN_URL_ENV: "https://attacker.example/login"},
+        ):
+            with self.assertRaisesRegex(WorkshopError, "may only target localhost"):
+                FactoryBrowserLogin(inventor_id="pico-press")
+
+    def test_rejects_noncanonical_inventor_id(self):
+        with self.assertRaisesRegex(WorkshopError, "canonical slug"):
+            FactoryBrowserLogin(inventor_id="Pico Press")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_codex_native_session.py
+++ b/tests/runtime/test_codex_native_session.py
@@ -414,6 +414,7 @@ class CodexNativeSessionTest(unittest.TestCase):
                 "OPENAI_API_KEY": "codex-auth",
                 "FACTORY_PASSWORD": "must-not-reach-codex",
                 "FACTORY_USERNAME": "must-not-reach-codex",
+                "FACTORY_INVENTOR_ID": "alice",
             }
             with mock.patch.dict(os.environ, parent_environment, clear=True):
                 outcome = self.start(
@@ -486,6 +487,7 @@ class CodexNativeSessionTest(unittest.TestCase):
             self.assertEqual(call["env"]["OPENAI_API_KEY"], "codex-auth")
             self.assertNotIn("FACTORY_PASSWORD", call["env"])
             self.assertNotIn("FACTORY_USERNAME", call["env"])
+            self.assertNotIn("FACTORY_INVENTOR_ID", call["env"])
             filesystem_override = next(
                 value
                 for value in command

--- a/tests/runtime/test_credentials.py
+++ b/tests/runtime/test_credentials.py
@@ -179,6 +179,8 @@ class FactoryCredentialBoundaryTest(unittest.TestCase):
             ({"FACTORY_USERNAME": "alice"}, "configured together"),
             ({"FACTORY_PASSWORD": "secret"}, "configured together"),
             ({"FACTORY_ALICE_USERNAME": "alice"}, "configured together"),
+            ({"FACTORY_INVENTOR_ID": "Pico Press"}, "inventor id is malformed"),
+            ({"FACTORY_INVENTOR_ID": "pico-press"}, "requires FACTORY_USERNAME"),
         )
         for values, message in invalid:
             with self.subTest(message=message), self.assertRaisesRegex(
@@ -236,7 +238,23 @@ class InventorAccountTest(unittest.TestCase):
         self.assertEqual(stat.S_IMODE(scoped.parent.stat().st_mode), 0o700)
         self.assertEqual(
             dict(factory_credential_environment(self.environment, inventor_id="pico-press")),
+            {
+                "FACTORY_USERNAME": "pico-press",
+                "FACTORY_PASSWORD": "p2",
+                "FACTORY_INVENTOR_ID": "pico-press",
+            },
+        )
+        self.assertEqual(
+            factory_service_credential_environment(
+                factory_credential_environment(
+                    self.environment, inventor_id="pico-press"
+                )
+            ),
             {"FACTORY_USERNAME": "pico-press", "FACTORY_PASSWORD": "p2"},
+        )
+        self.assertIn(
+            "FACTORY_INVENTOR_ID=pico-press\n",
+            scoped.read_text(encoding="utf-8"),
         )
         # An Inventor without its own account still publishes through the host pair.
         self.assertEqual(
@@ -248,6 +266,26 @@ class InventorAccountTest(unittest.TestCase):
             {"FACTORY_USERNAME": "house", "FACTORY_PASSWORD": "p1"},
         )
         self.assertTrue(shared.is_file())
+
+    def test_scoped_file_rejects_a_missing_or_mismatched_inventor_binding(self):
+        for binding in (None, "mira-fold"):
+            with self.subTest(binding=binding):
+                directory = self.home / "credentials" / "inventors"
+                directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+                os.chmod(directory, 0o700)
+                path = directory / "pico-press.env"
+                source = "FACTORY_USERNAME=khoa\nFACTORY_PASSWORD=agent-secret\n"
+                if binding is not None:
+                    source += "FACTORY_INVENTOR_ID=%s\n" % binding
+                path.write_text(source, encoding="utf-8")
+                os.chmod(path, 0o600)
+
+                with self.assertRaisesRegex(
+                    ContractError, "not bound to Inventor pico-press"
+                ):
+                    factory_credential_environment(
+                        self.environment, inventor_id="pico-press"
+                    )
 
     def test_storing_replaces_atomically_and_rejects_bad_input(self):
         from workshop.errors import ContractError


### PR DESCRIPTION
# Pull request

## Outcome

Give every Inventor its own shop account.

## Change class

- [x] Component implementation
- [x] Cross-component contract
- [x] CLI
- [x] Durable state or external effect
- [x] Documentation and release
- [x] Security-sensitive change

## Current and resulting behavior

Before:

- Publishing used host-wide Factory credentials.
- `create` and `start` did not connect an Inventor.

After:

- First `create` or `start` opens Autonomous login.
- Workshop exchanges a one-time PKCE code.
- Credentials are stored per Inventor.
- `workshop login <inventor-id>` reconnects or switches accounts.

Explicitly out of scope:

- Website and Autonomous Toys API deployment.

## Boundaries and contracts

- Public contract: browser login and per-Inventor credentials
- Consumers: CLI create/start/login and Factory publishing
- Dependency direction: CLI → Runtime → Integrations
- External effects: browser launch, loopback callback, HTTPS credential exchange
- Durable format: `$WORKSHOP_HOME/credentials/inventors/<id>.env`

- [x] Source and tests remain component-owned.
- [x] Components use public contracts.
- [x] Workflow remains the only stage sequencer.
- [x] Native-session boundaries remain unchanged.
- [x] CLI depends on Workshop.
- [x] No shared dumping ground added.

## Conditional review

### Inventor

N/A — no Inventor bundle changes.

### Skill or dependency

N/A — no skill or dependency changes.

### Schema, artifact, or durable state

- Format: new per-Inventor credential file
- Compatibility: existing host-wide credentials remain supported
- Hash impact: none
- Rollback: remove the per-Inventor credential and use legacy configuration

- [x] Existing credential configuration remains readable.
- [x] Historical records are not rewritten.
- [x] Malformed, partial, and mismatched credentials fail closed.

### Outside or physical effect

- Boundary: browser receives only a one-time code; Workshop performs the exchange
- Replay protection: state, PKCE, single callback claim, single-use code
- Ambiguous outcome: fail closed; rerun `workshop login`

- [x] No automatic effect retry.
- [x] Offline tests use fakes and claim no live readiness.

## Verification

```text
UV_CACHE_DIR=/tmp/workshop-uv-cache uv run python -m unittest \
  tests.runtime.test_browser_login \
  tests.runtime.test_credentials \
  tests.integrations.test_factory \
  tests.cli.test_cli

Ran 127 tests — OK

git diff --check origin/main...HEAD
Clean