### PR TITLE
Publish editable CAD Python sources

### DIFF
--- a/src/workshop/integrations/README.md
+++ b/src/workshop/integrations/README.md
@@ -30,6 +30,12 @@ derived, validates. Product-owned, stale, or malformed `*.step.json` files do
 not cross the effect boundary; the handoff safely narrows to the sealed root
 `assembled.stl` instead.
 
+For native Made results, the handoff also carries every sealed `.py` file under
+the exact declared CAD project path so a later Factory edit can regenerate the
+exports. Their paths, sizes, and hashes are recorded in the handoff facts.
+Python outside that project, `__cadgen__`/`__pycache__` content, renders, and
+verification output remain excluded.
+
 Public API: `workshop.integrations` exports the canonical Factory credentials,
 session, client, Release writer, and public transition. The adapter depends on
 runtime-owned `Receipt` and `EffectLedger` contracts; runtime never imports an

--- a/src/workshop/integrations/factory.py
+++ b/src/workshop/integrations/factory.py
@@ -117,6 +117,10 @@ FACTORY_MODEL_GEOMETRY_SUFFIXES = frozenset(
     )
 )
 FACTORY_MODEL_GENERATOR_SUFFIXES = frozenset((".py",))
+FACTORY_CAD_PYTHON_SOURCES_KIND = "workshop.cad-python-sources"
+FACTORY_CAD_PYTHON_EXCLUDED_DIRECTORIES = frozenset(
+    ("__cadgen__", "__pycache__")
+)
 # Only these sealed CAD types carry the per-part surface colours Make
 # assigned; a colour is read from the exact sealed bytes, never inferred
 # from a mesh, a render, or model prose.
@@ -242,6 +246,7 @@ def _is_factory_model_path(
     *,
     primary_kind: str,
     primary_path: Optional[str] = None,
+    python_source_paths: frozenset[str] = frozenset(),
 ) -> bool:
     pure = PurePosixPath(path)
     if (
@@ -258,9 +263,11 @@ def _is_factory_model_path(
         return True
     suffix = pure.suffix.casefold()
     return suffix in FACTORY_MODEL_GEOMETRY_SUFFIXES or (
-        primary_kind == "generator"
-        and path == primary_path
-        and suffix in FACTORY_MODEL_GENERATOR_SUFFIXES
+        suffix in FACTORY_MODEL_GENERATOR_SUFFIXES
+        and (
+            path in python_source_paths
+            or primary_kind == "generator" and path == primary_path
+        )
     )
 
 
@@ -340,6 +347,104 @@ def _sealed_primary(context: Any) -> Mapping[str, str]:
 
 def _manifest_entry(manifest: ArtifactManifest, path: str):
     return next((entry for entry in manifest.entries if entry.path == path), None)
+
+
+def _cad_python_source_entries(context: Any, manifest: ArtifactManifest):
+    """Select sealed editable Python sources from the declared CAD project only."""
+
+    project_path = getattr(context.made, "cad_project_path", None)
+    if project_path is None:
+        return ()
+    if not isinstance(project_path, str):
+        raise ContractError("Factory CAD project path is malformed")
+    project = PurePosixPath(project_path)
+    if (
+        not project_path
+        or project.is_absolute()
+        or project.as_posix() != project_path
+        or "\\" in project_path
+        or any(part in ("", ".", "..") for part in project.parts)
+    ):
+        raise ContractError("Factory CAD project path is malformed")
+    prefix = project.parts
+    entries = []
+    for entry in manifest.entries:
+        path = PurePosixPath(entry.path)
+        relative_parts = path.parts[len(prefix) :]
+        if (
+            path.parts[: len(prefix)] == prefix
+            and relative_parts
+            and path.suffix.casefold() in FACTORY_MODEL_GENERATOR_SUFFIXES
+            and not FACTORY_CAD_PYTHON_EXCLUDED_DIRECTORIES
+            & {part.casefold() for part in relative_parts}
+        ):
+            entries.append(entry)
+    return tuple(sorted(entries, key=lambda entry: entry.path))
+
+
+def _declared_cad_python_sources(
+    facts: Mapping[str, Any],
+) -> Mapping[str, Mapping[str, Any]]:
+    """Validate the self-describing Python-source inventory in one handoff."""
+
+    declaration = facts.get("cad_python_sources")
+    if declaration is None:
+        return {}
+    if not isinstance(declaration, Mapping) or set(declaration) != {
+        "schema_version",
+        "kind",
+        "project_path",
+        "files",
+    }:
+        raise ContractError("Factory CAD Python source declaration is malformed")
+    if (
+        declaration.get("schema_version") != 1
+        or declaration.get("kind") != FACTORY_CAD_PYTHON_SOURCES_KIND
+    ):
+        raise ContractError("Factory CAD Python source declaration is malformed")
+    project_path = declaration.get("project_path")
+    if not isinstance(project_path, str):
+        raise ContractError("Factory CAD Python source declaration is malformed")
+    project = PurePosixPath(project_path)
+    if (
+        not project_path
+        or project.is_absolute()
+        or project.as_posix() != project_path
+        or "\\" in project_path
+        or any(part in ("", ".", "..") for part in project.parts)
+    ):
+        raise ContractError("Factory CAD Python source declaration is malformed")
+    files = declaration.get("files")
+    if not isinstance(files, list) or not files:
+        raise ContractError("Factory CAD Python source declaration is malformed")
+    result: Dict[str, Mapping[str, Any]] = {}
+    for item in files:
+        if not isinstance(item, Mapping) or set(item) != {"path", "bytes", "sha256"}:
+            raise ContractError("Factory CAD Python source declaration is malformed")
+        path = item.get("path")
+        byte_count = item.get("bytes")
+        if not isinstance(path, str) or type(byte_count) is not int or byte_count < 0:
+            raise ContractError("Factory CAD Python source declaration is malformed")
+        pure = PurePosixPath(path)
+        relative_parts = pure.parts[len(project.parts) :]
+        if (
+            pure.parts[: len(project.parts)] != project.parts
+            or not relative_parts
+            or pure.suffix.casefold() not in FACTORY_MODEL_GENERATOR_SUFFIXES
+            or FACTORY_CAD_PYTHON_EXCLUDED_DIRECTORIES
+            & {part.casefold() for part in relative_parts}
+            or path in result
+        ):
+            raise ContractError("Factory CAD Python source declaration is malformed")
+        result[path] = {
+            "bytes": byte_count,
+            "sha256": require_sha256(
+                item.get("sha256"), "Factory CAD Python source sha256"
+            ),
+        }
+    if list(result) != sorted(result):
+        raise ContractError("Factory CAD Python source declaration is not canonical")
+    return result
 
 
 def _read_bound_file(root: Path, manifest: ArtifactManifest, path: str) -> bytes:
@@ -924,6 +1029,21 @@ def _assert_factory_handoff(content: bytes) -> None:
                 raise ContractError("Factory handoff primary model is missing") from exc
             if hashlib.sha256(primary_content).hexdigest() != primary_sha256:
                 raise ContractError("Factory handoff primary model hash differs")
+            python_sources = _declared_cad_python_sources(facts)
+            for source_path, binding in python_sources.items():
+                try:
+                    source_content = archive.read(source_path)
+                except KeyError as exc:
+                    raise ContractError(
+                        "Factory handoff CAD Python source is missing: %s" % source_path
+                    ) from exc
+                if (
+                    len(source_content) != binding["bytes"]
+                    or hashlib.sha256(source_content).hexdigest() != binding["sha256"]
+                ):
+                    raise ContractError(
+                        "Factory handoff CAD Python source differs: %s" % source_path
+                    )
             try:
                 release_page_content = archive.read(FACTORY_RELEASE_PAGE_PATH)
                 release_page = validate_release_product(
@@ -964,6 +1084,7 @@ def _assert_factory_handoff(content: bytes) -> None:
                     name,
                     primary_kind=primary_kind,
                     primary_path=primary_path,
+                    python_source_paths=frozenset(python_sources),
                 ):
                     raise ContractError(
                         "Factory model handoff contains non-model output: %s" % name
@@ -1012,6 +1133,8 @@ def _build_model_handoff(
     primary_entry = _manifest_entry(manifest, primary_source)
     if primary_entry is None or primary_entry.sha256 != primary_sha256:
         raise ContractError("Factory primary model is not sealed")
+    cad_python_sources = _cad_python_source_entries(context, manifest)
+    cad_python_source_paths = frozenset(entry.path for entry in cad_python_sources)
 
     # Keep assembled.stl at the root when Make provides it. Factory's importer
     # ranks that conventional name above all part meshes for the product viewer.
@@ -1034,6 +1157,20 @@ def _build_model_handoff(
     }
     transport_facts = dict(facts)
     transport_facts["primary_model"] = primary_model
+    if cad_python_sources:
+        transport_facts["cad_python_sources"] = {
+            "schema_version": 1,
+            "kind": FACTORY_CAD_PYTHON_SOURCES_KIND,
+            "project_path": context.made.cad_project_path,
+            "files": [
+                {
+                    "path": entry.path,
+                    "bytes": entry.bytes,
+                    "sha256": entry.sha256,
+                }
+                for entry in cad_python_sources
+            ],
+        }
     if occurrence is not None:
         occurrences = occurrence["occurrences"]
         transport_facts["factory_assembly"] = {
@@ -1130,6 +1267,7 @@ def _build_model_handoff(
                     entry.path,
                     primary_kind=sealed_primary["kind"],
                     primary_path=primary_source,
+                    python_source_paths=cad_python_source_paths,
                 )
                 or entry.path in skip_paths
             ):

--- a/src/workshop/make/contracts.py
+++ b/src/workshop/make/contracts.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Optional
 
 from workshop._validation import bounded_text, copy_json_mapping
 from workshop.artifacts.core import ArtifactManifest, build_artifact_manifest
@@ -25,6 +25,7 @@ class Made:
     artifact_root: Path
     artifact_manifest: ArtifactManifest
     product: Mapping[str, Any]
+    cad_project_path: Optional[str] = None
 
     def __post_init__(self) -> None:
         root = Path(self.artifact_root)
@@ -35,17 +36,41 @@ class Made:
         product = copy_json_mapping(self.product, "Made product", nonempty=True)
         for key in ("title", "summary"):
             bounded_text(product.get(key), "Made product %s" % key, 2_000)
+        if self.cad_project_path is not None:
+            if not isinstance(self.cad_project_path, str):
+                raise ContractError("Made cad_project_path must be a safe relative path")
+            project = PurePosixPath(self.cad_project_path)
+            if (
+                not self.cad_project_path
+                or project.is_absolute()
+                or project.as_posix() != self.cad_project_path
+                or "\\" in self.cad_project_path
+                or any(part in ("", ".", "..") for part in project.parts)
+            ):
+                raise ContractError("Made cad_project_path must be a safe relative path")
+            project_root = root.joinpath(*project.parts)
+            if project_root.is_symlink() or not project_root.is_dir():
+                raise ContractError(
+                    "Made cad_project_path must identify a regular directory"
+                )
         _fresh_manifest(root, self.artifact_manifest)
         object.__setattr__(self, "artifact_root", root.resolve(strict=True))
         object.__setattr__(self, "product", product)
 
     @classmethod
-    def from_root(cls, artifact_root: Path, product: Mapping[str, Any]) -> "Made":
+    def from_root(
+        cls,
+        artifact_root: Path,
+        product: Mapping[str, Any],
+        *,
+        cad_project_path: Optional[str] = None,
+    ) -> "Made":
         root = Path(artifact_root).resolve(strict=True)
         return cls(
             root,
             build_artifact_manifest(root, created_at="content-addressed"),
             product,
+            cad_project_path,
         )
 
     @property

--- a/src/workshop/make/native.py
+++ b/src/workshop/make/native.py
@@ -351,7 +351,12 @@ class NativeMade:
         )
         if cad_project.is_symlink() or not cad_project.is_dir():
             raise ArtifactError("native Made CAD project is unavailable")
-        return Made(product_root, self.product_manifest, page)
+        return Made(
+            product_root,
+            self.product_manifest,
+            page,
+            self.cad_project_path,
+        )
 
 
 __all__ = [

--- a/tests/integrations/test_factory.py
+++ b/tests/integrations/test_factory.py
@@ -542,6 +542,35 @@ class FactoryReleaseTest(unittest.TestCase):
             self.release, created_at="content-addressed"
         )
 
+    def _add_cad_python_project(self):
+        product = self.made.artifact_root
+        project = product / "cad/project"
+        (project / "parts").mkdir(parents=True)
+        (project / "__cadgen__").mkdir()
+        sources = {
+            "cad/project/assembled.step.py": b"from build import gen_step\n",
+            "cad/project/build.py": b"def gen_step():\n    return None\n",
+            "cad/project/parts/token.py": b"def token():\n    return None\n",
+        }
+        for relative, content in sources.items():
+            (product / relative).write_bytes(content)
+        (project / "__cadgen__/cached.py").write_bytes(b"generated cache\n")
+        self.made = Made.from_root(
+            product,
+            self.made.product,
+            cad_project_path="cad/project",
+        )
+        self.context = ReleaseContext(self.made)
+        release_page_path = self.release / "product.json"
+        release_page = json.loads(release_page_path.read_text(encoding="utf-8"))
+        release_page["product_artifact_sha256"] = self.made.artifact_sha256
+        release_page_path.write_bytes(canonical_json(release_page))
+        self.page = release_page
+        self.manifest = build_artifact_manifest(
+            self.release, created_at="content-addressed"
+        )
+        return sources
+
     def test_private_import_is_model_only_hash_bound_and_idempotent(self):
         transport = FactoryTransport()
         receipt = self.writer(transport)(self.context, self.release, self.manifest)
@@ -801,6 +830,71 @@ class FactoryReleaseTest(unittest.TestCase):
             )
             self.assertEqual(facts["wish"], self.context.wish.to_dict())
             self.assertEqual(facts["product"], dict(self.made.product))
+
+    def test_mesh_handoff_includes_only_declared_cad_project_python_sources(self):
+        sources = self._add_cad_python_project()
+        transport = FactoryTransport()
+
+        self.writer(transport)(self.context, self.release, self.manifest)
+
+        import_call = next(
+            call for call in transport.calls if call[1].endswith("/designs/import")
+        )
+        parts = multipart_parts(import_call[2], import_call[3])
+        with zipfile.ZipFile(io.BytesIO(parts["file"][0])) as archive:
+            names = set(archive.namelist())
+            self.assertTrue(set(sources) <= names)
+            self.assertNotIn("main.py", names)
+            self.assertNotIn("unrelated.py", names)
+            self.assertNotIn("cad/project/__cadgen__/cached.py", names)
+            facts = json.loads(archive.read("workshop-product-facts.json"))
+            declaration = facts["cad_python_sources"]
+            self.assertEqual(declaration["project_path"], "cad/project")
+            self.assertEqual(
+                [item["path"] for item in declaration["files"]],
+                sorted(sources),
+            )
+            for item in declaration["files"]:
+                content = archive.read(item["path"])
+                self.assertEqual(content, sources[item["path"]])
+                self.assertEqual(item["bytes"], len(content))
+                self.assertEqual(item["sha256"], hashlib.sha256(content).hexdigest())
+
+    def test_client_rejects_changed_declared_cad_python_source(self):
+        self._add_cad_python_project()
+        transport = FactoryTransport()
+        self.writer(transport)(self.context, self.release, self.manifest)
+        import_call = next(
+            call for call in transport.calls if call[1].endswith("/designs/import")
+        )
+        parts = multipart_parts(import_call[2], import_call[3])
+        tampered = io.BytesIO()
+        with (
+            zipfile.ZipFile(io.BytesIO(parts["file"][0])) as source,
+            zipfile.ZipFile(tampered, "w", zipfile.ZIP_DEFLATED) as target,
+        ):
+            for item in source.infolist():
+                content = source.read(item.filename)
+                if item.filename == "cad/project/build.py":
+                    content += b"# changed\n"
+                target.writestr(item, content)
+
+        client = FactoryClient(
+            lambda *_args, **_kwargs: self.fail("tampered handoff reached transport")
+        )
+        with self.assertRaisesRegex(ContractError, "CAD Python source differs"):
+            client.import_model(
+                filename="model-handoff.zip",
+                content=tampered.getvalue(),
+                metadata={
+                    "status": "draft",
+                    "title": "Verified Toy",
+                    "description": "An exact toy page authored before Factory import.",
+                    "category": FACTORY_TOY_CATEGORY_SLUG,
+                    "tags": ["toy"],
+                },
+                idempotency_key="test-tampered-cad-python-source",
+            )
 
     def test_release_manual_supersedes_made_manual_at_factory_boundary(self):
         product = self.made.artifact_root

--- a/tests/make/test_native_made.py
+++ b/tests/make/test_native_made.py
@@ -118,6 +118,7 @@ class NativeMadeTest(unittest.TestCase):
         self.assertEqual(canonical.artifact_root, product_root)
         self.assertEqual(canonical.artifact_sha256, made.product_manifest.artifact_sha256)
         self.assertEqual(canonical.product["title"], "Moon Nook")
+        self.assertEqual(canonical.cad_project_path, "cad/project")
 
     def test_tampered_tree_or_context_fails_closed(self):
         made, product_root = self._made()


### PR DESCRIPTION
# Pull request

## Outcome

<!-- What user, inventor, maintainer, or operator outcome does this change improve? -->

## Ownership

- Owning component:
- Primary DRI:
- Backup or second reviewer:
- Risk: standard / high / critical

<!-- Use .github/components.toml. Name every affected component for a contract change. -->

## Change class

- [ ] Component implementation
- [ ] Cross-component contract
- [ ] CLI
- [ ] Inventor specialist bundle or custom tool
- [ ] Product-run constitution or workflow skill
- [ ] Skill or locked dependency
- [ ] Schema, canonical bytes, or artifact identity
- [ ] Durable state, event, migration, receipt, or external effect
- [ ] Documentation, governance, CI, packaging, or release
- [ ] Security-sensitive change

## Current and resulting behavior

Before:

-

After:

-

Explicitly out of scope:

-

## Boundaries and contracts

- Public contract added or changed:
- Components consuming it:
- Dependency direction:
- External ports or effects:
- Durable formats read or written:

- [ ] The change stays in its owning source and mirrored test directories.
- [ ] Components import public contracts, not sibling private implementations.
- [ ] Workflow remains the only stage sequencer.
- [ ] Product work remains one persistent native session per Wish and one
      active Codex Goal per cognitive stage attempt; Python does not own the
      improvement loop.
- [ ] CLI and inventor code depend on Workshop; Workshop does not import them.
- [ ] No new `core`, `foundation`, `common`, or `utils` dumping ground was added.

## Conditional review

### Inventor

- Inventor ID and Taste boundary:
- Declared Codex skill trees:
- [ ] Root `TASTE.md` remains canonical and workflow-bound.
- [ ] The schema-v8 manifest and exact skill-tree hashes match the submitted bytes.
- [ ] The run materializes identity, Taste, and skill bindings only through `.codex/agents/`.
- [ ] Inventor scripts are deterministic specialist tools, not agent or lifecycle orchestration.
- [ ] Shared Workshop machinery is reused instead of copied.

### Skill or dependency

- Owner component:
- Source URL and exact revision:
- License and provenance record:
- Lock or fingerprint change:
- [ ] Executable modes and installed bytes were verified.
- [ ] A lock change represents an intentional byte change, not only a move.

### Schema, artifact, or durable state

- Format and old/new versions:
- Reader/writer compatibility:
- Canonicalization or hash impact:
- Rollback or reconciliation path:
- [ ] Existing state and evidence remain readable through tested readers.
- [ ] Historical records, receipts, hashes, and artifact bytes were not rewritten.
- [ ] Malformed, unknown, partial, retry, and ambiguous outcomes fail truthfully.

### Outside or physical effect

- Effect and authorization boundary:
- Idempotency key and receipt binding:
- Ambiguous-outcome behavior:
- [ ] Intent is durable before execution and retries cannot duplicate the effect.
- [ ] Offline tests use explicit fakes and do not claim live readiness.

## Verification

<!-- Paste exact commands and summarize results. Do not paste credentials. -->

```text

```

- [ ] Narrow component or CLI tests
- [ ] Contract/integration tests for every affected boundary
- [ ] Full repository test suite
- [ ] Architecture dependency checks
- [ ] Installed wheel and resource smoke tests when packaging/resources changed
- [ ] Skill/schema/runtime-asset identities when applicable
- [ ] Secret and provenance checks
- [ ] `git diff --check`

## Compatibility and release note

- [ ] Added `changes/<id>.<kind>.md`
- [ ] No changelog required; reason:
- Breaking Python API:
- Durable compatibility impact:
- Migration or deprecation window:

## Reviewer guide

<!-- Point reviewers to the highest-risk files, invariants, evidence, and tradeoffs. -->
